### PR TITLE
Improve / fix find expression in installPhase

### DIFF
--- a/derivation.nix
+++ b/derivation.nix
@@ -13,11 +13,15 @@ let
     '';
     # keep only *.{pom,jar,sha1,nbm} and delete all ephemeral files with lastModified timestamps inside
     installPhase = ''
-        find $out/.m2 -type f -regex '.+\\(\\.lastUpdated\\|resolver-status\\.properties\\|_remote\\.repositories\\)' -delete
+      find $out/.m2 -type f \
+        -name \*.lastUpdated -or \
+        -name resolver-status.properties -or \
+        -name _remote.repositories \
+        -delete
     '';
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "026wmcpbdvkm7xizxgg0c12z4sl88n2h7bdwvvk6r7y5b6q18nsf";
+    outputHash = "1ax9hlbsrmjf1h327rs5vklx2c310h6clhd56pvyb79pc0k6ya7h";
   };
 in mkDerivation rec {
   pname = "mvn2nix";


### PR DESCRIPTION
The old version didn't work properly as it didn't actually match any
of the desired files. This resulted in unstable output hashes. Also,
the regex approach would have erroneously matched files which contain
the sought after strings as substrings. This patch simplifies the
expression to use basic `-name` matchers.