### PR TITLE
Add the ability to specify an optional JDK

### DIFF
--- a/src/main/java/com/fzakaria/mvn2nix/cmd/Maven2nix.java
+++ b/src/main/java/com/fzakaria/mvn2nix/cmd/Maven2nix.java
@@ -57,6 +57,12 @@ public class Maven2nix implements Callable<Integer> {
             defaultValue = "https://repo.maven.apache.org/maven2/")
     private String[] repositories;
 
+    @Option(names = "--jdk",
+            arity = "0..*",
+            description = "The JDK to use when running Maven",
+            defaultValue = "${java.home}")
+    private File javaHome;
+    
     public Maven2nix() {
     }
 
@@ -65,7 +71,7 @@ public class Maven2nix implements Callable<Integer> {
         LOGGER.info("Reading {}", file);
 
         final Maven maven = Maven.withTemporaryLocalRepository();
-        maven.executeGoals(file, goals);
+        maven.executeGoals(file, javaHome, goals);
 
         Collection<Artifact> artifacts = maven.collectAllArtifactsInLocalRepository();
         Map<String, MavenArtifact> dependencies = artifacts.parallelStream()

--- a/src/main/java/com/fzakaria/mvn2nix/maven/Maven.java
+++ b/src/main/java/com/fzakaria/mvn2nix/maven/Maven.java
@@ -89,11 +89,12 @@ public class Maven {
         return Optional.of(file);
     }
 
-    public void executeGoals(File pom, String... goals) throws MavenInvocationException {
+    public void executeGoals(File pom, File javaHome, String... goals) throws MavenInvocationException {
         InvocationRequest request = new DefaultInvocationRequest();
         request.setGoals(Lists.newArrayList(goals));
         request.setBatchMode(true);
         request.setPomFile(pom);
+        request.setJavaHome(javaHome);
 
         /*
          * Load a custom settings.xml file that sets ~/.m2/repository as a remote repo.


### PR DESCRIPTION
We'd like to support passing through the JDK to execute with
MavenInvoker.

The mvn2nix CLI now accepts a `jdk` command line flag.
You can now do something like:
```bash
mvn2nix --jdk $(nix eval nixpkgs.jdk8.home)
```

Fixed #36