### PR TITLE
pin maven-resources-plugin 2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,11 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M5</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>2.6</version>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
fix build with latest nixpkgs and latest jdk

build error was:

> Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.0 or one of its dependencies could not be resolved

adding missing dependencies to mvn2nix-lock.json does not help, the build fails with another error:

> Error injecting: org.apache.maven.plugins.resources.ResourcesMojo
> Failed to execute goal org.apache.maven.plugins:maven-resources-plugin:3.3.0:resources (default-resources) on project mvn2nix
> No implementation for MavenResourcesFiltering was bound.

im using mvn2nix in my [nur-packages](https://github.com/milahu/nur-packages) to build mwdumper:

- [pkgs/mwdumper/mwdumper.nix](https://github.com/milahu/nur-packages/blob/master/pkgs/mwdumper/mwdumper.nix)
- [pkgs/development/tools/mvn2nix/mvn2nix.nix](https://github.com/milahu/nur-packages/blob/master/pkgs/development/tools/mvn2nix/mvn2nix.nix) called by [default.nix](https://github.com/milahu/nur-packages/blob/31caccb789dcce013c675e4fdfa53c41769542b6/default.nix#L238-L244)
