### PR TITLE
Predictable artifact order

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v20
         with:
-          install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20201221_9fab14a/install
           extra_nix_config: experimental-features = nix-command flakes
       - uses: cachix/cachix-action@v8
         with:
@@ -49,7 +48,6 @@ jobs:
     - uses: actions/checkout@v2.3.2
     - uses: cachix/install-nix-action@v20
       with:
-        install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20201221_9fab14a/install
         extra_nix_config: experimental-features = nix-command flakes
     - uses: cachix/cachix-action@v8
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.2
-      - uses: cachix/install-nix-action@v12
+      - uses: cachix/install-nix-action@v20
       - uses: cachix/cachix-action@v8
         with:
           name: fzakaria
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.3.2
-    - uses: cachix/install-nix-action@v12
+    - uses: cachix/install-nix-action@v20
     - uses: cachix/cachix-action@v8
       with:
         name: fzakaria
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v12
+      - uses: cachix/install-nix-action@v20
         with:
           install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20201221_9fab14a/install
           extra_nix_config: experimental-features = nix-command flakes
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.3.2
-    - uses: cachix/install-nix-action@v12
+    - uses: cachix/install-nix-action@v20
       with:
         install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20201221_9fab14a/install
         extra_nix_config: experimental-features = nix-command flakes

--- a/src/main/java/com/fzakaria/mvn2nix/cmd/Maven2nix.java
+++ b/src/main/java/com/fzakaria/mvn2nix/cmd/Maven2nix.java
@@ -104,6 +104,8 @@ public class Maven2nix implements Callable<Integer> {
 
     /**
      * Convert this object to a pretty JSON representation.
+     *
+     * The artifacts will appear in the order induced by {@link String#compareTo(String)}.
      */
     public static String toPrettyJson(MavenNixInformation information) {
         final Moshi moshi = new Moshi.Builder()

--- a/src/main/java/com/fzakaria/mvn2nix/maven/Maven.java
+++ b/src/main/java/com/fzakaria/mvn2nix/maven/Maven.java
@@ -12,8 +12,6 @@ import org.apache.maven.shared.invoker.InvocationResult;
 import org.apache.maven.shared.invoker.Invoker;
 import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.apache.maven.shared.invoker.PrintStreamHandler;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,8 +31,6 @@ import java.util.stream.StreamSupport;
  * https://maven.apache.org/shared/maven-invoker/index.html
  */
 public class Maven {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(Maven.class);
 
     private final Invoker invoker;
     private final File localRepository;

--- a/src/main/java/com/fzakaria/mvn2nix/maven/Maven.java
+++ b/src/main/java/com/fzakaria/mvn2nix/maven/Maven.java
@@ -16,7 +16,6 @@ import org.apache.maven.shared.invoker.PrintStreamHandler;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;

--- a/src/main/java/com/fzakaria/mvn2nix/model/MavenArtifact.java
+++ b/src/main/java/com/fzakaria/mvn2nix/model/MavenArtifact.java
@@ -23,10 +23,6 @@ public class MavenArtifact {
         return url;
     }
 
-    public String getLayout() {
-        return layout;
-    }
-
     public String getSha256() {
         return sha256;
     }

--- a/src/main/java/com/fzakaria/mvn2nix/model/MavenNixInformation.java
+++ b/src/main/java/com/fzakaria/mvn2nix/model/MavenNixInformation.java
@@ -15,11 +15,7 @@ public class MavenNixInformation {
     public MavenNixInformation(Map<String, MavenArtifact> dependencies) {
         this.dependencies = new HashMap<>(dependencies);
     }
-
-    public Map<String, MavenArtifact> getDependencies() {
-        return new HashMap<>(dependencies);
-    }
-
+    
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/com/fzakaria/mvn2nix/model/MavenNixInformation.java
+++ b/src/main/java/com/fzakaria/mvn2nix/model/MavenNixInformation.java
@@ -6,6 +6,7 @@ import javax.annotation.concurrent.Immutable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.TreeMap;
 
 @Immutable
 public class MavenNixInformation {
@@ -13,9 +14,9 @@ public class MavenNixInformation {
     private final Map<String, MavenArtifact> dependencies;
 
     public MavenNixInformation(Map<String, MavenArtifact> dependencies) {
-        this.dependencies = new HashMap<>(dependencies);
+        this.dependencies = new TreeMap<>(dependencies);
     }
-    
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/com/fzakaria/mvn2nix/model/MavenNixInformation.java
+++ b/src/main/java/com/fzakaria/mvn2nix/model/MavenNixInformation.java
@@ -13,6 +13,10 @@ public class MavenNixInformation {
 
     private final Map<String, MavenArtifact> dependencies;
 
+    /**
+     * Stores the given dependencies in a tree map to get the artifacts in alphabetic order when this
+     * object is converted to json by {@link com.fzakaria.mvn2nix.cmd.Maven2nix#toPrettyJson}.
+     */
     public MavenNixInformation(Map<String, MavenArtifact> dependencies) {
         this.dependencies = new TreeMap<>(dependencies);
     }

--- a/src/test/java/com/fzakaria/mvn2nix/cmd/Maven2nixTest.java
+++ b/src/test/java/com/fzakaria/mvn2nix/cmd/Maven2nixTest.java
@@ -1,0 +1,36 @@
+package com.fzakaria.mvn2nix.cmd;
+
+import com.fzakaria.mvn2nix.model.MavenArtifact;
+import com.fzakaria.mvn2nix.model.MavenNixInformation;
+import org.junit.jupiter.api.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class Maven2nixTest {
+
+    @Test
+    void artifactsInJsonShouldBeInAlphabeticOrder() throws MalformedURLException {
+        var artifacts = new MavenNixInformation(Map.of(
+                "artifact-b", new MavenArtifact(new URL("https://dummy/url/b"), "b", "sha256-b"),
+                "artifact-a", new MavenArtifact(new URL("https://dummy/url/a"), "a", "sha256-a")));
+        assertEquals("{\n" +
+                "  \"dependencies\": {\n" +
+                "    \"artifact-a\": {\n" +
+                "      \"layout\": \"a\",\n" +
+                "      \"sha256\": \"sha256-a\",\n" +
+                "      \"url\": \"https://dummy/url/a\"\n" +
+                "    },\n" +
+                "    \"artifact-b\": {\n" +
+                "      \"layout\": \"b\",\n" +
+                "      \"sha256\": \"sha256-b\",\n" +
+                "      \"url\": \"https://dummy/url/b\"\n" +
+                "    }\n" +
+                "  }\n" +
+                "}", Maven2nix.toPrettyJson(artifacts));
+    }
+
+}

--- a/src/test/resources/samples/basic/mvn2nix-lock.json
+++ b/src/test/resources/samples/basic/mvn2nix-lock.json
@@ -1,5 +1,95 @@
 {
   "dependencies": {
+    "backport-util-concurrent:backport-util-concurrent:pom:3.1": {
+      "layout": "backport-util-concurrent/backport-util-concurrent/3.1/backport-util-concurrent-3.1.pom",
+      "sha256": "770471090ca40a17b9e436ee2ec00819be42042da6f4085ece1d37916dc08ff9",
+      "url": "https://repo.maven.apache.org/maven2/backport-util-concurrent/backport-util-concurrent/3.1/backport-util-concurrent-3.1.pom"
+    },
+    "classworlds:classworlds:jar:1.1": {
+      "layout": "classworlds/classworlds/1.1/classworlds-1.1.jar",
+      "sha256": "4e3e0ad158ec60917e0de544c550f31cd65d5a97c3af1c1968bf427e4a9df2e4",
+      "url": "https://repo.maven.apache.org/maven2/classworlds/classworlds/1.1/classworlds-1.1.jar"
+    },
+    "classworlds:classworlds:jar:1.1-alpha-2": {
+      "layout": "classworlds/classworlds/1.1-alpha-2/classworlds-1.1-alpha-2.jar",
+      "sha256": "2bf4e59f3acd106fea6145a9a88fe8956509f8b9c0fdd11eb96fee757269e3f3",
+      "url": "https://repo.maven.apache.org/maven2/classworlds/classworlds/1.1-alpha-2/classworlds-1.1-alpha-2.jar"
+    },
+    "classworlds:classworlds:pom:1.1": {
+      "layout": "classworlds/classworlds/1.1/classworlds-1.1.pom",
+      "sha256": "25a1efc00bcd1f029fd20c44df843b8b12d1fa17485235470764f011d2f5cb29",
+      "url": "https://repo.maven.apache.org/maven2/classworlds/classworlds/1.1/classworlds-1.1.pom"
+    },
+    "classworlds:classworlds:pom:1.1-alpha-2": {
+      "layout": "classworlds/classworlds/1.1-alpha-2/classworlds-1.1-alpha-2.pom",
+      "sha256": "0cc647963b74ad1d7a37c9868e9e5a8f474e49297e1863582253a08a4c719cb1",
+      "url": "https://repo.maven.apache.org/maven2/classworlds/classworlds/1.1-alpha-2/classworlds-1.1-alpha-2.pom"
+    },
+    "com.google.code.findbugs:jsr305:jar:2.0.1": {
+      "layout": "com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.jar",
+      "sha256": "1e7f53fa5b8b5c807e986ba335665da03f18d660802d8bf061823089d1bee468",
+      "url": "https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.jar"
+    },
+    "com.google.code.findbugs:jsr305:pom:2.0.1": {
+      "layout": "com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.pom",
+      "sha256": "02c12c3c2ae12dd475219ff691c82a4d9ea21f44bc594a181295bf6d43dcfbb0",
+      "url": "https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.pom"
+    },
+    "com.google.collections:google-collections:jar:1.0": {
+      "layout": "com/google/collections/google-collections/1.0/google-collections-1.0.jar",
+      "sha256": "81b8d638af0083c4b877099d56aa0fee714485cd2ace1b6a09cab867cadb375d",
+      "url": "https://repo.maven.apache.org/maven2/com/google/collections/google-collections/1.0/google-collections-1.0.jar"
+    },
+    "com.google.collections:google-collections:pom:1.0": {
+      "layout": "com/google/collections/google-collections/1.0/google-collections-1.0.pom",
+      "sha256": "893d56afcea1b22f83220fd7e49a6668c5b8901e39bd59dc57b42f55673721ce",
+      "url": "https://repo.maven.apache.org/maven2/com/google/collections/google-collections/1.0/google-collections-1.0.pom"
+    },
+    "com.google:google:pom:1": {
+      "layout": "com/google/google/1/google-1.pom",
+      "sha256": "cd6db17a11a31ede794ccbd1df0e4d9750f640234731f21cff885a9997277e81",
+      "url": "https://repo.maven.apache.org/maven2/com/google/google/1/google-1.pom"
+    },
+    "commons-cli:commons-cli:jar:1.0": {
+      "layout": "commons-cli/commons-cli/1.0/commons-cli-1.0.jar",
+      "sha256": "43f24850b7b7b7d79c5fa652418518fbdf427e602b1edabe6f11b85fb93eb013",
+      "url": "https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.0/commons-cli-1.0.jar"
+    },
+    "commons-cli:commons-cli:pom:1.0": {
+      "layout": "commons-cli/commons-cli/1.0/commons-cli-1.0.pom",
+      "sha256": "97ee40f4e80ca5ecc20162f4e97ee1adfeac1b45ba88b923d5a521e487c9c407",
+      "url": "https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.0/commons-cli-1.0.pom"
+    },
+    "commons-lang:commons-lang:jar:2.1": {
+      "layout": "commons-lang/commons-lang/2.1/commons-lang-2.1.jar",
+      "sha256": "2ded7343dc8e57decd5e6302337139be020fdd885a2935925e8d575975e480b9",
+      "url": "https://repo.maven.apache.org/maven2/commons-lang/commons-lang/2.1/commons-lang-2.1.jar"
+    },
+    "commons-lang:commons-lang:pom:2.1": {
+      "layout": "commons-lang/commons-lang/2.1/commons-lang-2.1.pom",
+      "sha256": "f1a709cd489f23498a0b6b3dfbfc0d21d4f15904791446dec7f8a58a7da5bd6a",
+      "url": "https://repo.maven.apache.org/maven2/commons-lang/commons-lang/2.1/commons-lang-2.1.pom"
+    },
+    "commons-logging:commons-logging-api:jar:1.1": {
+      "layout": "commons-logging/commons-logging-api/1.1/commons-logging-api-1.1.jar",
+      "sha256": "33a4dd47bb4764e4eb3692d86386d17a0d9827f4f4bb0f70121efab6bc03ba35",
+      "url": "https://repo.maven.apache.org/maven2/commons-logging/commons-logging-api/1.1/commons-logging-api-1.1.jar"
+    },
+    "commons-logging:commons-logging-api:pom:1.1": {
+      "layout": "commons-logging/commons-logging-api/1.1/commons-logging-api-1.1.pom",
+      "sha256": "69b8be61aa746c7d02acb1b11eb3b57cb22b246780ed71d79764195cbbe3d99d",
+      "url": "https://repo.maven.apache.org/maven2/commons-logging/commons-logging-api/1.1/commons-logging-api-1.1.pom"
+    },
+    "junit:junit:jar:3.8.1": {
+      "layout": "junit/junit/3.8.1/junit-3.8.1.jar",
+      "sha256": "b58e459509e190bed737f3592bc1950485322846cf10e78ded1d065153012d70",
+      "url": "https://repo.maven.apache.org/maven2/junit/junit/3.8.1/junit-3.8.1.jar"
+    },
+    "junit:junit:jar:3.8.2": {
+      "layout": "junit/junit/3.8.2/junit-3.8.2.jar",
+      "sha256": "ecdcc08183708ea3f7b0ddc96f19678a0db8af1fb397791d484aed63200558b0",
+      "url": "https://repo.maven.apache.org/maven2/junit/junit/3.8.2/junit-3.8.2.jar"
+    },
     "junit:junit:pom:3.8.1": {
       "layout": "junit/junit/3.8.1/junit-3.8.1.pom",
       "sha256": "e68f33343d832398f3c8aa78afcd808d56b7c1020de4d3ad8ce47909095ee904",
@@ -10,300 +100,250 @@
       "sha256": "aede67999f02ac851c2a2ae8cec58f9d801f826ba20994df23a1d9fbecc47f0f",
       "url": "https://repo.maven.apache.org/maven2/junit/junit/3.8.2/junit-3.8.2.pom"
     },
-    "org.sonatype.forge:forge-parent:pom:10": {
-      "layout": "org/sonatype/forge/forge-parent/10/forge-parent-10.pom",
-      "sha256": "c14fb9c32b59cc03251f609416db7c0cff01f811edcccb4f6a865d6e7046bd0b",
-      "url": "https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/10/forge-parent-10.pom"
+    "log4j:log4j:jar:1.2.12": {
+      "layout": "log4j/log4j/1.2.12/log4j-1.2.12.jar",
+      "sha256": "dc67378cf428c06408e7959e83bdc1518dd22ccd313e7c28a986612d65c276c7",
+      "url": "https://repo.maven.apache.org/maven2/log4j/log4j/1.2.12/log4j-1.2.12.jar"
+    },
+    "log4j:log4j:pom:1.2.12": {
+      "layout": "log4j/log4j/1.2.12/log4j-1.2.12.pom",
+      "sha256": "cb54dedc5d8c4510148dfa792701cbac1a84c383a84f48f5a32e6d7e460bbb72",
+      "url": "https://repo.maven.apache.org/maven2/log4j/log4j/1.2.12/log4j-1.2.12.pom"
+    },
+    "org.apache.commons:commons-lang3:jar:3.1": {
+      "layout": "org/apache/commons/commons-lang3/3.1/commons-lang3-3.1.jar",
+      "sha256": "131f0519a8e4602e47cf024bfd7e0834bcf5592a7207f9a2fdb711d4f5afc166",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.1/commons-lang3-3.1.jar"
+    },
+    "org.apache.commons:commons-lang3:pom:3.1": {
+      "layout": "org/apache/commons/commons-lang3/3.1/commons-lang3-3.1.pom",
+      "sha256": "043ab78d83f630af65c0c0e4289d584d5a816c82533814f3f7fac4b5509fded2",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.1/commons-lang3-3.1.pom"
     },
     "org.apache.commons:commons-parent:pom:22": {
       "layout": "org/apache/commons/commons-parent/22/commons-parent-22.pom",
       "sha256": "fb8c5e55e30a7addb4ff210858a0e8d2494ed6757bbe19012da99d51586c3cbb",
       "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/22/commons-parent-22.pom"
     },
-    "org.codehaus.plexus:plexus-compiler:pom:2.2": {
-      "layout": "org/codehaus/plexus/plexus-compiler/2.2/plexus-compiler-2.2.pom",
-      "sha256": "1d94e9a3f048c9eaaba0016ea188a4e7029c6849b8708ff6dc900a34fe03c28c",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler/2.2/plexus-compiler-2.2.pom"
+    "org.apache.maven.doxia:doxia-sink-api:jar:1.0-alpha-7": {
+      "layout": "org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7/doxia-sink-api-1.0-alpha-7.jar",
+      "sha256": "37e66f15f348df957538f81f7e10a3fdcf84e5fbd687b2001ee3d6ab4a25aafe",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7/doxia-sink-api-1.0-alpha-7.jar"
     },
-    "org.codehaus.plexus:plexus-interpolation:pom:1.11": {
-      "layout": "org/codehaus/plexus/plexus-interpolation/1.11/plexus-interpolation-1.11.pom",
-      "sha256": "b84d281f59b9da528139e0752a0e1cab0bd98d52c58442b00e45c9748e1d9eee",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.11/plexus-interpolation-1.11.pom"
+    "org.apache.maven.doxia:doxia-sink-api:pom:1.0-alpha-7": {
+      "layout": "org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7/doxia-sink-api-1.0-alpha-7.pom",
+      "sha256": "3b0fa210dcbf0c92545ac31740fc2dd8af61dc72fd452cfca3d68aeabb642003",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7/doxia-sink-api-1.0-alpha-7.pom"
     },
-    "org.codehaus.plexus:plexus-interpolation:pom:1.12": {
-      "layout": "org/codehaus/plexus/plexus-interpolation/1.12/plexus-interpolation-1.12.pom",
-      "sha256": "9e1d13d08550026de20cf8120b7e62e0ee842fc9df94140974c082b067fa5b72",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.12/plexus-interpolation-1.12.pom"
+    "org.apache.maven.doxia:doxia:pom:1.0-alpha-7": {
+      "layout": "org/apache/maven/doxia/doxia/1.0-alpha-7/doxia-1.0-alpha-7.pom",
+      "sha256": "172106a7ac51408883a074a1b847768e71c40fbbd969c8d645d2570026b811be",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia/1.0-alpha-7/doxia-1.0-alpha-7.pom"
     },
-    "org.codehaus.plexus:plexus-components:pom:1.1.19": {
-      "layout": "org/codehaus/plexus/plexus-components/1.1.19/plexus-components-1.1.19.pom",
-      "sha256": "d3e7f3adf5d002c01f362760ad1c2dce98e6354009a7c07c0a105c3eccb17159",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.19/plexus-components-1.1.19.pom"
+    "org.apache.maven.plugin-tools:maven-plugin-annotations:jar:3.1": {
+      "layout": "org/apache/maven/plugin-tools/maven-plugin-annotations/3.1/maven-plugin-annotations-3.1.jar",
+      "sha256": "8de51faf9303a49a479e8fd01608166a035f16d259086c84f62afdae2c18617b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugin-tools/maven-plugin-annotations/3.1/maven-plugin-annotations-3.1.jar"
     },
-    "org.codehaus.plexus:plexus-interpolation:pom:1.15": {
-      "layout": "org/codehaus/plexus/plexus-interpolation/1.15/plexus-interpolation-1.15.pom",
-      "sha256": "4a9f28e95f82a80fbd0632e6305b3c676f4d5e946f93028226d5365f53492bc7",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.15/plexus-interpolation-1.15.pom"
+    "org.apache.maven.plugin-tools:maven-plugin-annotations:pom:3.1": {
+      "layout": "org/apache/maven/plugin-tools/maven-plugin-annotations/3.1/maven-plugin-annotations-3.1.pom",
+      "sha256": "e48a5204cfacc45a0885ff5ca0a6e78001d472e21ec1d7255e3210b53f0ee1a5",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugin-tools/maven-plugin-annotations/3.1/maven-plugin-annotations-3.1.pom"
     },
-    "org.apache.maven.surefire:surefire-api:pom:2.12.4": {
-      "layout": "org/apache/maven/surefire/surefire-api/2.12.4/surefire-api-2.12.4.pom",
-      "sha256": "58bc67922a9c370e59fbc592c5a7ee2ba17fd23d0ffdd58190e5c41358547123",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/2.12.4/surefire-api-2.12.4.pom"
-    },
-    "org.apache.maven:maven-error-diagnostics:pom:2.0.9": {
-      "layout": "org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9.pom",
-      "sha256": "581cf29ef72ebbaeff78a8054482ea8a4cd43e6d905f4adb7a16edf1636a619b",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9.pom"
-    },
-    "org.codehaus.plexus:plexus-components:pom:1.1.15": {
-      "layout": "org/codehaus/plexus/plexus-components/1.1.15/plexus-components-1.1.15.pom",
-      "sha256": "7940cd305323b8409fdb7e78398f6efd8ff8a642c7dd8f353e519abe91ab0da3",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.15/plexus-components-1.1.15.pom"
-    },
-    "org.codehaus.plexus:plexus-interpolation:pom:1.13": {
-      "layout": "org/codehaus/plexus/plexus-interpolation/1.13/plexus-interpolation-1.13.pom",
-      "sha256": "e37731ea5ed19d276f33b77c93399fb5df026e1191133b15fbeab73342c6363b",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.13/plexus-interpolation-1.13.pom"
-    },
-    "org.codehaus.plexus:plexus-components:pom:1.1.14": {
-      "layout": "org/codehaus/plexus/plexus-components/1.1.14/plexus-components-1.1.14.pom",
-      "sha256": "381d72c526be217b770f9f8c3f749a86d3b1548ac5c1fcb48d267530ec60d43f",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.14/plexus-components-1.1.14.pom"
-    },
-    "org.apache.maven:maven-error-diagnostics:pom:2.0.6": {
-      "layout": "org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.pom",
-      "sha256": "cb80662bd8274131bb09e140a4075bff660bdab5be56bf0f926efee0389f3c4e",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.pom"
-    },
-    "org.apache.maven.reporting:maven-reporting:pom:2.0.9": {
-      "layout": "org/apache/maven/reporting/maven-reporting/2.0.9/maven-reporting-2.0.9.pom",
-      "sha256": "168340af95f5ba50362c015d88d8dc7ef5737456d65484df8c3a2f4631ea5789",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting/2.0.9/maven-reporting-2.0.9.pom"
-    },
-    "org.codehaus.plexus:plexus-io:jar:2.0.2": {
-      "layout": "org/codehaus/plexus/plexus-io/2.0.2/plexus-io-2.0.2.jar",
-      "sha256": "e2f88c8813463aabfb1b689f0be551c24c58e8e5508fd5a44f8d20a327b1517f",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/2.0.2/plexus-io-2.0.2.jar"
-    },
-    "com.google.code.findbugs:jsr305:jar:2.0.1": {
-      "layout": "com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.jar",
-      "sha256": "1e7f53fa5b8b5c807e986ba335665da03f18d660802d8bf061823089d1bee468",
-      "url": "https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.jar"
-    },
-    "classworlds:classworlds:jar:1.1-alpha-2": {
-      "layout": "classworlds/classworlds/1.1-alpha-2/classworlds-1.1-alpha-2.jar",
-      "sha256": "2bf4e59f3acd106fea6145a9a88fe8956509f8b9c0fdd11eb96fee757269e3f3",
-      "url": "https://repo.maven.apache.org/maven2/classworlds/classworlds/1.1-alpha-2/classworlds-1.1-alpha-2.jar"
-    },
-    "org.apache.maven:maven-project:pom:2.0.6": {
-      "layout": "org/apache/maven/maven-project/2.0.6/maven-project-2.0.6.pom",
-      "sha256": "7dd6468c154d99c39a94c7a8c734aa96366864334b6b2ea10778459860cbe3e5",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.6/maven-project-2.0.6.pom"
-    },
-    "org.apache.maven:maven-project:pom:2.0.9": {
-      "layout": "org/apache/maven/maven-project/2.0.9/maven-project-2.0.9.pom",
-      "sha256": "fa8043afdbe232e7541b965386dc582be336783ac220aadc9bde401b02295a90",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.9/maven-project-2.0.9.pom"
-    },
-    "org.apache.maven:maven-plugin-api:pom:2.0.9": {
-      "layout": "org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9.pom",
-      "sha256": "0ef1a886c795b5ca48d08245b13d1128ecbc6fd0f05e6556749547df9978680b",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9.pom"
-    },
-    "org.codehaus.plexus:plexus-container-default:jar:1.5.5": {
-      "layout": "org/codehaus/plexus/plexus-container-default/1.5.5/plexus-container-default-1.5.5.jar",
-      "sha256": "69197486cd80beb54b4e0fcabaa325ec2d4e2636e9b245c472435c87a10931cf",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.5.5/plexus-container-default-1.5.5.jar"
-    },
-    "org.apache.maven:maven-toolchain:jar:2.0.9": {
-      "layout": "org/apache/maven/maven-toolchain/2.0.9/maven-toolchain-2.0.9.jar",
-      "sha256": "dcbddf7cbc3bb03f76afdeb598491ae815620c5ff66cf8f18d7239d1dc764dc8",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/2.0.9/maven-toolchain-2.0.9.jar"
-    },
-    "org.sonatype.plexus:plexus-sec-dispatcher:pom:1.3": {
-      "layout": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.pom",
-      "sha256": "d5e650c50ef6958c028ed024b59af04cf3d38e1453a77d542b6b484bc0f4ca0b",
-      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.pom"
-    },
-    "org.apache.maven:maven:pom:2.0.9": {
-      "layout": "org/apache/maven/maven/2.0.9/maven-2.0.9.pom",
-      "sha256": "6db25755b962d443bd7698b87654f336de43fd5319cbcc000e2e72c08c3619b4",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.0.9/maven-2.0.9.pom"
-    },
-    "org.codehaus.plexus:plexus-utils:pom:2.0.5": {
-      "layout": "org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.pom",
-      "sha256": "35bc7d1213616236571072b2c56da18f7a57658de8b4a4100645b7054a2b273b",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.pom"
-    },
-    "org.apache.maven:maven:pom:2.0.6": {
-      "layout": "org/apache/maven/maven/2.0.6/maven-2.0.6.pom",
-      "sha256": "f5755c01058f048c61c3baf11e03c605b9c0ec1021ab40a3dcb76fb5bf51ff34",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.0.6/maven-2.0.6.pom"
-    },
-    "org.sonatype.plexus:plexus-cipher:pom:1.4": {
-      "layout": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.pom",
-      "sha256": "a63a2e23988cca7fac6c93886d6f0506fd26d88d7e8cc0cb89b9c6e0d6c994ad",
-      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.pom"
-    },
-    "org.codehaus.plexus:plexus-utils:pom:1.5.15": {
-      "layout": "org/codehaus/plexus/plexus-utils/1.5.15/plexus-utils-1.5.15.pom",
-      "sha256": "12a3c9a32b82fdc95223cab1f9d344e14ef3e396da14c4d0013451646f3280e7",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.15/plexus-utils-1.5.15.pom"
-    },
-    "backport-util-concurrent:backport-util-concurrent:pom:3.1": {
-      "layout": "backport-util-concurrent/backport-util-concurrent/3.1/backport-util-concurrent-3.1.pom",
-      "sha256": "770471090ca40a17b9e436ee2ec00819be42042da6f4085ece1d37916dc08ff9",
-      "url": "https://repo.maven.apache.org/maven2/backport-util-concurrent/backport-util-concurrent/3.1/backport-util-concurrent-3.1.pom"
-    },
-    "commons-logging:commons-logging-api:jar:1.1": {
-      "layout": "commons-logging/commons-logging-api/1.1/commons-logging-api-1.1.jar",
-      "sha256": "33a4dd47bb4764e4eb3692d86386d17a0d9827f4f4bb0f70121efab6bc03ba35",
-      "url": "https://repo.maven.apache.org/maven2/commons-logging/commons-logging-api/1.1/commons-logging-api-1.1.jar"
+    "org.apache.maven.plugin-tools:maven-plugin-tools:pom:3.1": {
+      "layout": "org/apache/maven/plugin-tools/maven-plugin-tools/3.1/maven-plugin-tools-3.1.pom",
+      "sha256": "ea3422417c914115799d62be376bcf8f79f05b896905f84e9da55af5af66abec",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugin-tools/maven-plugin-tools/3.1/maven-plugin-tools-3.1.pom"
     },
     "org.apache.maven.plugins:maven-compiler-plugin:jar:3.1": {
       "layout": "org/apache/maven/plugins/maven-compiler-plugin/3.1/maven-compiler-plugin-3.1.jar",
       "sha256": "62286cd88a4bfa04e31c52415a61c4cc5611b7e814fbc96be6f217d5d3c302c6",
       "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.1/maven-compiler-plugin-3.1.jar"
     },
-    "org.apache.maven:maven-profile:jar:2.0.6": {
-      "layout": "org/apache/maven/maven-profile/2.0.6/maven-profile-2.0.6.jar",
-      "sha256": "89c07a73ea3b41e6c3c7e126871c898f1741fbfddd35633f9524fda09c25dc01",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.6/maven-profile-2.0.6.jar"
+    "org.apache.maven.plugins:maven-compiler-plugin:pom:3.1": {
+      "layout": "org/apache/maven/plugins/maven-compiler-plugin/3.1/maven-compiler-plugin-3.1.pom",
+      "sha256": "45940a032f78466dd1686acb5769eca3ecc9baf7ca9a3517c138887d8cbe8b1c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.1/maven-compiler-plugin-3.1.pom"
+    },
+    "org.apache.maven.plugins:maven-jar-plugin:jar:2.4": {
+      "layout": "org/apache/maven/plugins/maven-jar-plugin/2.4/maven-jar-plugin-2.4.jar",
+      "sha256": "1f22f2e528daddbc5d06518c4dbe4d5f4fa6995c8441c702ee5d7d506bb4b4f3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/2.4/maven-jar-plugin-2.4.jar"
+    },
+    "org.apache.maven.plugins:maven-jar-plugin:pom:2.4": {
+      "layout": "org/apache/maven/plugins/maven-jar-plugin/2.4/maven-jar-plugin-2.4.pom",
+      "sha256": "a98f60925af4a1729529a1e9c5aba78ffdd024c67a8f825ed974a0ab006d315a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/2.4/maven-jar-plugin-2.4.pom"
+    },
+    "org.apache.maven.plugins:maven-plugins:pom:22": {
+      "layout": "org/apache/maven/plugins/maven-plugins/22/maven-plugins-22.pom",
+      "sha256": "34d303bbdd31d34f5a1570549b0e134b72afb18db53d8fcfdad222d51e941630",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/22/maven-plugins-22.pom"
+    },
+    "org.apache.maven.plugins:maven-plugins:pom:23": {
+      "layout": "org/apache/maven/plugins/maven-plugins/23/maven-plugins-23.pom",
+      "sha256": "e07710c7d516a873c8fcafe85840d8a1a78f460c9a364d1c57b1d9e4554639ce",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/23/maven-plugins-23.pom"
+    },
+    "org.apache.maven.plugins:maven-plugins:pom:24": {
+      "layout": "org/apache/maven/plugins/maven-plugins/24/maven-plugins-24.pom",
+      "sha256": "bfba38bd72d1a898f6f88e17cea240c67426be64d00c166b29c461d9bc149e56",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/24/maven-plugins-24.pom"
+    },
+    "org.apache.maven.plugins:maven-resources-plugin:jar:2.6": {
+      "layout": "org/apache/maven/plugins/maven-resources-plugin/2.6/maven-resources-plugin-2.6.jar",
+      "sha256": "07bd1b98b5b029af91fabcf99a9b3463b9dc09b993f28c2ee0ccc98265888ca6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/2.6/maven-resources-plugin-2.6.jar"
+    },
+    "org.apache.maven.plugins:maven-resources-plugin:pom:2.6": {
+      "layout": "org/apache/maven/plugins/maven-resources-plugin/2.6/maven-resources-plugin-2.6.pom",
+      "sha256": "a7842d002fbc7d2a84217106be909bc85ea35aa47031e410ab8afbb3b3364e2d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/2.6/maven-resources-plugin-2.6.pom"
+    },
+    "org.apache.maven.plugins:maven-surefire-plugin:jar:2.12.4": {
+      "layout": "org/apache/maven/plugins/maven-surefire-plugin/2.12.4/maven-surefire-plugin-2.12.4.jar",
+      "sha256": "da14e7c9643cd3991355730455324a46ac83d633da6446cde96ef8356afa42f4",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/2.12.4/maven-surefire-plugin-2.12.4.jar"
+    },
+    "org.apache.maven.plugins:maven-surefire-plugin:pom:2.12.4": {
+      "layout": "org/apache/maven/plugins/maven-surefire-plugin/2.12.4/maven-surefire-plugin-2.12.4.pom",
+      "sha256": "91e7b0ac3866d8932cf12a5c676223f48b1c4a4c65b9a73e150cae96418abfbc",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/2.12.4/maven-surefire-plugin-2.12.4.pom"
+    },
+    "org.apache.maven.reporting:maven-reporting-api:jar:2.0.6": {
+      "layout": "org/apache/maven/reporting/maven-reporting-api/2.0.6/maven-reporting-api-2.0.6.jar",
+      "sha256": "ba372ac9e52b481671bb3ea913063cd66747780de340d0c3b1f18c49ec998786",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.0.6/maven-reporting-api-2.0.6.jar"
+    },
+    "org.apache.maven.reporting:maven-reporting-api:jar:2.0.9": {
+      "layout": "org/apache/maven/reporting/maven-reporting-api/2.0.9/maven-reporting-api-2.0.9.jar",
+      "sha256": "b43cd126a7dde90857cb9ad6a46ce65787a6597fec729b509a074e6d087e893a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.0.9/maven-reporting-api-2.0.9.jar"
+    },
+    "org.apache.maven.reporting:maven-reporting-api:pom:2.0.6": {
+      "layout": "org/apache/maven/reporting/maven-reporting-api/2.0.6/maven-reporting-api-2.0.6.pom",
+      "sha256": "4ac659858bac5929ea8fc183d7ce4b588d7e69363a76277f6a26349393686657",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.0.6/maven-reporting-api-2.0.6.pom"
+    },
+    "org.apache.maven.reporting:maven-reporting-api:pom:2.0.9": {
+      "layout": "org/apache/maven/reporting/maven-reporting-api/2.0.9/maven-reporting-api-2.0.9.pom",
+      "sha256": "e50e96c88041e2236420e5483b407175c07f401b0d49f0744fa48de2d372448d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.0.9/maven-reporting-api-2.0.9.pom"
+    },
+    "org.apache.maven.reporting:maven-reporting:pom:2.0.6": {
+      "layout": "org/apache/maven/reporting/maven-reporting/2.0.6/maven-reporting-2.0.6.pom",
+      "sha256": "ab803be997ac806ee7f2e179ad3cda640345ed8fc911082b1f80202c7fc463a4",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting/2.0.6/maven-reporting-2.0.6.pom"
+    },
+    "org.apache.maven.reporting:maven-reporting:pom:2.0.9": {
+      "layout": "org/apache/maven/reporting/maven-reporting/2.0.9/maven-reporting-2.0.9.pom",
+      "sha256": "168340af95f5ba50362c015d88d8dc7ef5737456d65484df8c3a2f4631ea5789",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting/2.0.9/maven-reporting-2.0.9.pom"
+    },
+    "org.apache.maven.shared:maven-common-artifact-filters:jar:1.3": {
+      "layout": "org/apache/maven/shared/maven-common-artifact-filters/1.3/maven-common-artifact-filters-1.3.jar",
+      "sha256": "eabb4ba67917a8d5762f35f35314105bac2265588295c6b77a4feac9d210a336",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/1.3/maven-common-artifact-filters-1.3.jar"
+    },
+    "org.apache.maven.shared:maven-common-artifact-filters:pom:1.3": {
+      "layout": "org/apache/maven/shared/maven-common-artifact-filters/1.3/maven-common-artifact-filters-1.3.pom",
+      "sha256": "7587bc31ee5285debdb0b87b3446ccece28c2716820232adc0089295e84c265d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/1.3/maven-common-artifact-filters-1.3.pom"
     },
     "org.apache.maven.shared:maven-filtering:jar:1.1": {
       "layout": "org/apache/maven/shared/maven-filtering/1.1/maven-filtering-1.1.jar",
       "sha256": "05fa641c31894ce930c6eb76ec1aa53a9de4cd9baa837fe492e9e0407099d226",
       "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-filtering/1.1/maven-filtering-1.1.jar"
     },
-    "org.codehaus.plexus:plexus-interpolation:jar:1.15": {
-      "layout": "org/codehaus/plexus/plexus-interpolation/1.15/plexus-interpolation-1.15.jar",
-      "sha256": "7111a4eb5f137781b68127a5a02d0208c28f26d2626fbd7a81d1172cd56449a8",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.15/plexus-interpolation-1.15.jar"
+    "org.apache.maven.shared:maven-filtering:pom:1.1": {
+      "layout": "org/apache/maven/shared/maven-filtering/1.1/maven-filtering-1.1.pom",
+      "sha256": "9f4bf710d0de3c4dde45182aae3d604784b4e2f91696e27f3411286ef96d181c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-filtering/1.1/maven-filtering-1.1.pom"
     },
-    "org.apache.maven.plugins:maven-compiler-plugin:pom:3.1": {
-      "layout": "org/apache/maven/plugins/maven-compiler-plugin/3.1/maven-compiler-plugin-3.1.pom",
-      "sha256": "45940a032f78466dd1686acb5769eca3ecc9baf7ca9a3517c138887d8cbe8b1c",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/3.1/maven-compiler-plugin-3.1.pom"
+    "org.apache.maven.shared:maven-shared-components:pom:12": {
+      "layout": "org/apache/maven/shared/maven-shared-components/12/maven-shared-components-12.pom",
+      "sha256": "231a3c87248f98eed75cc32512adb5837b8141e52ba94af0fdb3e10292e1766e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/12/maven-shared-components-12.pom"
     },
-    "org.apache.maven:maven-core:pom:2.0.9": {
-      "layout": "org/apache/maven/maven-core/2.0.9/maven-core-2.0.9.pom",
-      "sha256": "1ae908507b9781902c425f261af8aa1bf5cf77632a69534aee479887787ee059",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9.pom"
+    "org.apache.maven.shared:maven-shared-components:pom:17": {
+      "layout": "org/apache/maven/shared/maven-shared-components/17/maven-shared-components-17.pom",
+      "sha256": "4b96931a6d12491f858b44b2dbea50c1070c960232c041b966189dc905ac2631",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/17/maven-shared-components-17.pom"
     },
-    "org.apache.maven:maven-profile:pom:2.0.9": {
-      "layout": "org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9.pom",
-      "sha256": "3be51b8a7e080ae0a765e870fa8c3acaab2a916ec24cbf0bb468d5d8abcbc104",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9.pom"
+    "org.apache.maven.shared:maven-shared-components:pom:18": {
+      "layout": "org/apache/maven/shared/maven-shared-components/18/maven-shared-components-18.pom",
+      "sha256": "a1d54fb81b5a8f197f5b3d0a928f63da2278c79bc8dd06e0be93593403f05775",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/18/maven-shared-components-18.pom"
     },
-    "org.apache.maven:maven-core:pom:2.0.6": {
-      "layout": "org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.pom",
-      "sha256": "1ab7fdd1b82382690c081d3ea3f53bad2902e1d62a11a8096488711e7a5f607e",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.pom"
+    "org.apache.maven.shared:maven-shared-components:pom:19": {
+      "layout": "org/apache/maven/shared/maven-shared-components/19/maven-shared-components-19.pom",
+      "sha256": "d82408269aada2eb1521ee8ff17f7c67333684f8ed2a09a9e35badd2e7575957",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/19/maven-shared-components-19.pom"
     },
-    "org.apache.maven:maven-profile:pom:2.0.6": {
-      "layout": "org/apache/maven/maven-profile/2.0.6/maven-profile-2.0.6.pom",
-      "sha256": "09455abf6ab86671fab0ae5bba8293c17382c8a9c53fafc3befb3e0720f2b707",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.6/maven-profile-2.0.6.pom"
+    "org.apache.maven.shared:maven-shared-incremental:jar:1.1": {
+      "layout": "org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.jar",
+      "sha256": "61988e54486a5dc38f06c70fdae5b108556c63bd433697b9f4305fcdb30fa40e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.jar"
     },
-    "org.apache.maven.surefire:surefire-booter:pom:2.12.4": {
-      "layout": "org/apache/maven/surefire/surefire-booter/2.12.4/surefire-booter-2.12.4.pom",
-      "sha256": "1f52e6773f75a33eea6dc8803c1012b0f4cdafb030f087aa649559f90bf24dc9",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/2.12.4/surefire-booter-2.12.4.pom"
+    "org.apache.maven.shared:maven-shared-incremental:pom:1.1": {
+      "layout": "org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.pom",
+      "sha256": "f21d19eb49b4a66cd85354a9ee7335439ea92a368173760a202766008cc19924",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.pom"
     },
-    "org.codehaus.plexus:plexus:pom:3.0.1": {
-      "layout": "org/codehaus/plexus/plexus/3.0.1/plexus-3.0.1.pom",
-      "sha256": "1649f67caab553dd7e6b98002dcc670dab3f624c78f1259c8323e705b0c41e32",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/3.0.1/plexus-3.0.1.pom"
+    "org.apache.maven.shared:maven-shared-utils:jar:0.1": {
+      "layout": "org/apache/maven/shared/maven-shared-utils/0.1/maven-shared-utils-0.1.jar",
+      "sha256": "86cd563b0bb40b0ef4e7183e41768049ad0afaca5b5acbf9680c53c217ca93d7",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/0.1/maven-shared-utils-0.1.jar"
     },
-    "org.codehaus.plexus:plexus-interpolation:jar:1.13": {
-      "layout": "org/codehaus/plexus/plexus-interpolation/1.13/plexus-interpolation-1.13.jar",
-      "sha256": "8e149132ff32907f39560398e222f1733ae959cedd099b32ee31c7b9d3bc1d6f",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.13/plexus-interpolation-1.13.jar"
+    "org.apache.maven.shared:maven-shared-utils:pom:0.1": {
+      "layout": "org/apache/maven/shared/maven-shared-utils/0.1/maven-shared-utils-0.1.pom",
+      "sha256": "9ecb36b0e0d7d1d0f0dabd8705368b710df58b943091e9fa9071a29ccdc15a33",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/0.1/maven-shared-utils-0.1.pom"
     },
-    "org.apache.maven:maven-profile:jar:2.0.9": {
-      "layout": "org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9.jar",
-      "sha256": "88fe952eaf4e28da0533ceef5d8e9b7fc9f09f7f825ab342130bf4b8c3805664",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9.jar"
+    "org.apache.maven.surefire:maven-surefire-common:jar:2.12.4": {
+      "layout": "org/apache/maven/surefire/maven-surefire-common/2.12.4/maven-surefire-common-2.12.4.jar",
+      "sha256": "5fa774434507bea2edcf4496536c88f883926cc6baf121b5af172fa494aaa30d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/2.12.4/maven-surefire-common-2.12.4.jar"
     },
-    "org.apache.maven:maven-repository-metadata:pom:2.0.9": {
-      "layout": "org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9.pom",
-      "sha256": "0447b3919bc7d0301b763852aca8dc0e87ccfbe34a4d5257f7f4fae8a4e87998",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9.pom"
+    "org.apache.maven.surefire:maven-surefire-common:pom:2.12.4": {
+      "layout": "org/apache/maven/surefire/maven-surefire-common/2.12.4/maven-surefire-common-2.12.4.pom",
+      "sha256": "14df735a04e945f31198b4e9cbfddd103d238108d4f35bf77441216f0c4a4b29",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/2.12.4/maven-surefire-common-2.12.4.pom"
     },
     "org.apache.maven.surefire:surefire-api:jar:2.12.4": {
       "layout": "org/apache/maven/surefire/surefire-api/2.12.4/surefire-api-2.12.4.jar",
       "sha256": "84f6a8a5ca6072eee7b48592e3e491d7bb85f24faebbc5fcf4c745056d5d8dfb",
       "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/2.12.4/surefire-api-2.12.4.jar"
     },
-    "org.apache.maven:maven-repository-metadata:pom:2.0.6": {
-      "layout": "org/apache/maven/maven-repository-metadata/2.0.6/maven-repository-metadata-2.0.6.pom",
-      "sha256": "df10657745e39010954fd009276b65b75198bdc40d0adb9916f9697c71fcd986",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.6/maven-repository-metadata-2.0.6.pom"
+    "org.apache.maven.surefire:surefire-api:pom:2.12.4": {
+      "layout": "org/apache/maven/surefire/surefire-api/2.12.4/surefire-api-2.12.4.pom",
+      "sha256": "58bc67922a9c370e59fbc592c5a7ee2ba17fd23d0ffdd58190e5c41358547123",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-api/2.12.4/surefire-api-2.12.4.pom"
     },
-    "org.codehaus.plexus:plexus-utils:jar:2.0.5": {
-      "layout": "org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.jar",
-      "sha256": "b4c51a337078b934ad656ee78a2d3a805a507129dc034692c67db0f94b659d3e",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.jar"
+    "org.apache.maven.surefire:surefire-booter:jar:2.12.4": {
+      "layout": "org/apache/maven/surefire/surefire-booter/2.12.4/surefire-booter-2.12.4.jar",
+      "sha256": "ad03864f1373c48da45ea25570e4950cd144fea7c08bd040f82f524ea4e1047f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/2.12.4/surefire-booter-2.12.4.jar"
     },
-    "org.apache.maven:maven-parent:pom:8": {
-      "layout": "org/apache/maven/maven-parent/8/maven-parent-8.pom",
-      "sha256": "3cb6712f827c80dc6b0b0b967776dba451c023a92b7741bba45d23ab7a83281a",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/8/maven-parent-8.pom"
+    "org.apache.maven.surefire:surefire-booter:pom:2.12.4": {
+      "layout": "org/apache/maven/surefire/surefire-booter/2.12.4/surefire-booter-2.12.4.pom",
+      "sha256": "1f52e6773f75a33eea6dc8803c1012b0f4cdafb030f087aa649559f90bf24dc9",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/2.12.4/surefire-booter-2.12.4.pom"
     },
-    "org.codehaus.plexus:plexus-container-default:pom:1.5.5": {
-      "layout": "org/codehaus/plexus/plexus-container-default/1.5.5/plexus-container-default-1.5.5.pom",
-      "sha256": "3f0dc324ff65ccdbd6bb3df39136e2878047a2b0c19799689bcefa4132bdcba4",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.5.5/plexus-container-default-1.5.5.pom"
+    "org.apache.maven.surefire:surefire:pom:2.12.4": {
+      "layout": "org/apache/maven/surefire/surefire/2.12.4/surefire-2.12.4.pom",
+      "sha256": "71aeb7883b53ef63a5f6282f957dcfd09a6891707fe938b85939d814f2247e82",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire/2.12.4/surefire-2.12.4.pom"
     },
-    "org.apache.maven:maven-parent:pom:5": {
-      "layout": "org/apache/maven/maven-parent/5/maven-parent-5.pom",
-      "sha256": "5d7c2a229173155823c45380332f221bf0d27e52c9db76e9217940306765bd50",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/5/maven-parent-5.pom"
+    "org.apache.maven:maven-archiver:jar:2.5": {
+      "layout": "org/apache/maven/maven-archiver/2.5/maven-archiver-2.5.jar",
+      "sha256": "9fd34ed18dc5a49011380e620be86314f9f734193b8fcf85fb11e7b3a3929d6e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/2.5/maven-archiver-2.5.jar"
     },
-    "org.codehaus.plexus:plexus-component-annotations:pom:1.5.5": {
-      "layout": "org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.pom",
-      "sha256": "815f3ec316b8c5fa701385fdf4009bfb51e07d780e8f6a6e2afe720c52d7e292",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.pom"
-    },
-    "org.sonatype.forge:forge-parent:pom:3": {
-      "layout": "org/sonatype/forge/forge-parent/3/forge-parent-3.pom",
-      "sha256": "03263b68791fb11e7464ffcc2c3de7eaeae235de8c94827ce6407e0454d2aae9",
-      "url": "https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/3/forge-parent-3.pom"
-    },
-    "org.sonatype.forge:forge-parent:pom:5": {
-      "layout": "org/sonatype/forge/forge-parent/5/forge-parent-5.pom",
-      "sha256": "e56188aa8ce51278006aa90bc7e0f304a81e2f1219f462e7d21f262535cd2795",
-      "url": "https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/5/forge-parent-5.pom"
-    },
-    "org.sonatype.forge:forge-parent:pom:4": {
-      "layout": "org/sonatype/forge/forge-parent/4/forge-parent-4.pom",
-      "sha256": "1838d132479005b4b7459b798e9d9915515090c288082fdcd86db0b10983a24c",
-      "url": "https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/4/forge-parent-4.pom"
-    },
-    "org.codehaus.plexus:plexus-components:pom:1.3.1": {
-      "layout": "org/codehaus/plexus/plexus-components/1.3.1/plexus-components-1.3.1.pom",
-      "sha256": "8cbcb2aacd7f4a7759866ce91b2f910310fbe5a586b5fc7b9bdb76af9257e7c4",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.3.1/plexus-components-1.3.1.pom"
-    },
-    "org.codehaus.plexus:plexus-archiver:jar:2.1": {
-      "layout": "org/codehaus/plexus/plexus-archiver/2.1/plexus-archiver-2.1.jar",
-      "sha256": "5a49a4c13e29da41c24bbb35b2f94b82bde259e25d4dd55ee3159e31d20677b8",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/2.1/plexus-archiver-2.1.jar"
-    },
-    "org.slf4j:slf4j-api:pom:1.5.6": {
-      "layout": "org/slf4j/slf4j-api/1.5.6/slf4j-api-1.5.6.pom",
-      "sha256": "91b0a0d016b8c0cba1ddd8a5c59e5bf5c2a9b49b95577e8e38927a7fdff55ce8",
-      "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.5.6/slf4j-api-1.5.6.pom"
-    },
-    "org.apache.maven:maven-artifact:pom:2.2.1": {
-      "layout": "org/apache/maven/maven-artifact/2.2.1/maven-artifact-2.2.1.pom",
-      "sha256": "f658a628efd6e0efe416b977638ba144af660fe6413f3637a4d03feb6a1ce806",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.2.1/maven-artifact-2.2.1.pom"
-    },
-    "org.apache.maven:maven-error-diagnostics:jar:2.0.6": {
-      "layout": "org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.jar",
-      "sha256": "59c637b910c0de53d28aeeb6444ee5fe1a8fa8f3da32dbbc4485250c166d3fee",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.jar"
+    "org.apache.maven:maven-archiver:pom:2.5": {
+      "layout": "org/apache/maven/maven-archiver/2.5/maven-archiver-2.5.pom",
+      "sha256": "86214750be31034691143c797a2656bc647f0defeb4988031aa5afaf39f16a31",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/2.5/maven-archiver-2.5.pom"
     },
     "org.apache.maven:maven-artifact-manager:jar:2.0.6": {
       "layout": "org/apache/maven/maven-artifact-manager/2.0.6/maven-artifact-manager-2.0.6.jar",
@@ -315,95 +355,95 @@
       "sha256": "d913865e03e719ac5733260019e98090a12b50683134e65f78c36e8d67f11ff1",
       "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9.jar"
     },
-    "org.apache:apache:pom:13": {
-      "layout": "org/apache/apache/13/apache-13.pom",
-      "sha256": "ff513db0361fd41237bef4784968bc15aae478d4ec0a9496f811072ccaf3841d",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/13/apache-13.pom"
+    "org.apache.maven:maven-artifact-manager:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-artifact-manager/2.0.6/maven-artifact-manager-2.0.6.pom",
+      "sha256": "a80884dfac999ebdda57904f929a14f28ab08e5411d515bdb1fbdaacf0ed6d6f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.6/maven-artifact-manager-2.0.6.pom"
     },
-    "org.apache.maven:maven-plugin-registry:pom:2.0.6": {
-      "layout": "org/apache/maven/maven-plugin-registry/2.0.6/maven-plugin-registry-2.0.6.pom",
-      "sha256": "cf633e8cde33e65580776d845756d332d24f7c6d5bf9ae90fc6c43d73cb5fe23",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0.6/maven-plugin-registry-2.0.6.pom"
+    "org.apache.maven:maven-artifact-manager:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9.pom",
+      "sha256": "d573bbb1b78c76523c45aba2859d390883b932dfde67e3c2032fc443c0fa098d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9.pom"
     },
-    "org.apache.maven:maven-error-diagnostics:jar:2.0.9": {
-      "layout": "org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9.jar",
-      "sha256": "c16be9fd50777338fa36d09c5c037b2d9ef9b68f00c67e9aa54b2d2b19fbf8f2",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9.jar"
-    },
-    "org.codehaus.plexus:plexus:pom:3.3.1": {
-      "layout": "org/codehaus/plexus/plexus/3.3.1/plexus-3.3.1.pom",
-      "sha256": "6ec96f889bc29250f90b167c14e547f1b05aa23565c63f9079595befbde816bb",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/3.3.1/plexus-3.3.1.pom"
-    },
-    "org.codehaus.plexus:plexus-interactivity-api:pom:1.0-alpha-4": {
-      "layout": "org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.pom",
-      "sha256": "42aada809ec125bbfe4d38f9d196bbeb59f298b389df96e610269e369b8eb2c9",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.pom"
-    },
-    "org.apache.maven:maven-plugin-registry:pom:2.0.9": {
-      "layout": "org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9.pom",
-      "sha256": "7de23d8212885031dc2e6fabc327957ff8324563a8fbeb10b0a85b498b826667",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9.pom"
-    },
-    "org.apache:apache:pom:11": {
-      "layout": "org/apache/apache/11/apache-11.pom",
-      "sha256": "9a4fb5addb41d8116b6441e9e3c48764d9cc562243d5608652bea6db0509297b",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/11/apache-11.pom"
-    },
-    "org.apache:apache:pom:10": {
-      "layout": "org/apache/apache/10/apache-10.pom",
-      "sha256": "802feece72852dafcbd0a425a60367c72c5cb9b6ea5aae59481128569189daf9",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/10/apache-10.pom"
-    },
-    "org.apache.maven:maven-archiver:pom:2.5": {
-      "layout": "org/apache/maven/maven-archiver/2.5/maven-archiver-2.5.pom",
-      "sha256": "86214750be31034691143c797a2656bc647f0defeb4988031aa5afaf39f16a31",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/2.5/maven-archiver-2.5.pom"
-    },
-    "org.apache.xbean:xbean-reflect:jar:3.4": {
-      "layout": "org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.jar",
-      "sha256": "17e0efa187127034623197fb88c50c30d3baa62baa0f07d6ec693047ac92ec3b",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.jar"
-    },
-    "org.apache.maven.doxia:doxia-sink-api:pom:1.0-alpha-7": {
-      "layout": "org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7/doxia-sink-api-1.0-alpha-7.pom",
-      "sha256": "3b0fa210dcbf0c92545ac31740fc2dd8af61dc72fd452cfca3d68aeabb642003",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7/doxia-sink-api-1.0-alpha-7.pom"
-    },
-    "org.apache.maven:maven-artifact:jar:2.0.9": {
-      "layout": "org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9.jar",
-      "sha256": "0b16842a33350f5478c4c717bf664251c27459ec5c0b8d0ca4d0050545aba48b",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9.jar"
-    },
-    "org.apache.maven.plugins:maven-jar-plugin:pom:2.4": {
-      "layout": "org/apache/maven/plugins/maven-jar-plugin/2.4/maven-jar-plugin-2.4.pom",
-      "sha256": "a98f60925af4a1729529a1e9c5aba78ffdd024c67a8f825ed974a0ab006d315a",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/2.4/maven-jar-plugin-2.4.pom"
+    "org.apache.maven:maven-artifact-manager:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-artifact-manager/2.2.1/maven-artifact-manager-2.2.1.pom",
+      "sha256": "ecf58351f8fe0c398b8b452216705bece5291b9b327d30202c16b28ac680450c",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.2.1/maven-artifact-manager-2.2.1.pom"
     },
     "org.apache.maven:maven-artifact:jar:2.0.6": {
       "layout": "org/apache/maven/maven-artifact/2.0.6/maven-artifact-2.0.6.jar",
       "sha256": "f45629a70af0dfec1c1b542e162a2aceb976bb492825b6ee192e6a14fff238b6",
       "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.6/maven-artifact-2.0.6.jar"
     },
-    "org.codehaus.plexus:plexus-compiler-manager:pom:2.2": {
-      "layout": "org/codehaus/plexus/plexus-compiler-manager/2.2/plexus-compiler-manager-2.2.pom",
-      "sha256": "bf2aedb6f801096d0b7f9db201fef9ceb0696b801c446ada188144cae4e91dd2",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-manager/2.2/plexus-compiler-manager-2.2.pom"
+    "org.apache.maven:maven-artifact:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9.jar",
+      "sha256": "0b16842a33350f5478c4c717bf664251c27459ec5c0b8d0ca4d0050545aba48b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9.jar"
+    },
+    "org.apache.maven:maven-artifact:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-artifact/2.0.6/maven-artifact-2.0.6.pom",
+      "sha256": "7231047667b34a36cfed19d51ef38c9755e97e1acf11595a4b503c5ce7f0c595",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.6/maven-artifact-2.0.6.pom"
+    },
+    "org.apache.maven:maven-artifact:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9.pom",
+      "sha256": "77f614225a71c207a45f270be0190d34bac4dbc14684cda26015717710411aee",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9.pom"
+    },
+    "org.apache.maven:maven-artifact:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-artifact/2.2.1/maven-artifact-2.2.1.pom",
+      "sha256": "f658a628efd6e0efe416b977638ba144af660fe6413f3637a4d03feb6a1ce806",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.2.1/maven-artifact-2.2.1.pom"
+    },
+    "org.apache.maven:maven-core:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.jar",
+      "sha256": "710d56c05add33beadea2f86254223955aca570c15a610f81be07c96c919d7b6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.jar"
+    },
+    "org.apache.maven:maven-core:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-core/2.0.9/maven-core-2.0.9.jar",
+      "sha256": "da9bdd720f0b1861fe649a2edf8fc0a65e4e2c4a1a05d8d96adbfaa1319f7285",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9.jar"
+    },
+    "org.apache.maven:maven-core:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.pom",
+      "sha256": "1ab7fdd1b82382690c081d3ea3f53bad2902e1d62a11a8096488711e7a5f607e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.pom"
+    },
+    "org.apache.maven:maven-core:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-core/2.0.9/maven-core-2.0.9.pom",
+      "sha256": "1ae908507b9781902c425f261af8aa1bf5cf77632a69534aee479887787ee059",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9.pom"
+    },
+    "org.apache.maven:maven-core:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-core/2.2.1/maven-core-2.2.1.pom",
+      "sha256": "5cc81603cab47bf20dbfd5e28e311da1fd26f2e3617b50547da5cd0b4f59edf3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.2.1/maven-core-2.2.1.pom"
+    },
+    "org.apache.maven:maven-error-diagnostics:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.jar",
+      "sha256": "59c637b910c0de53d28aeeb6444ee5fe1a8fa8f3da32dbbc4485250c166d3fee",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.jar"
+    },
+    "org.apache.maven:maven-error-diagnostics:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9.jar",
+      "sha256": "c16be9fd50777338fa36d09c5c037b2d9ef9b68f00c67e9aa54b2d2b19fbf8f2",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9.jar"
+    },
+    "org.apache.maven:maven-error-diagnostics:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.pom",
+      "sha256": "cb80662bd8274131bb09e140a4075bff660bdab5be56bf0f926efee0389f3c4e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.6/maven-error-diagnostics-2.0.6.pom"
+    },
+    "org.apache.maven:maven-error-diagnostics:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9.pom",
+      "sha256": "581cf29ef72ebbaeff78a8054482ea8a4cd43e6d905f4adb7a16edf1636a619b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.0.9/maven-error-diagnostics-2.0.9.pom"
     },
     "org.apache.maven:maven-error-diagnostics:pom:2.2.1": {
       "layout": "org/apache/maven/maven-error-diagnostics/2.2.1/maven-error-diagnostics-2.2.1.pom",
       "sha256": "228367b7569fb1462a3eb1423bc2778e2fc7fbaee3d3767890c02b8924fa1889",
       "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-error-diagnostics/2.2.1/maven-error-diagnostics-2.2.1.pom"
-    },
-    "org.apache.maven.plugin-tools:maven-plugin-annotations:pom:3.1": {
-      "layout": "org/apache/maven/plugin-tools/maven-plugin-annotations/3.1/maven-plugin-annotations-3.1.pom",
-      "sha256": "e48a5204cfacc45a0885ff5ca0a6e78001d472e21ec1d7255e3210b53f0ee1a5",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugin-tools/maven-plugin-annotations/3.1/maven-plugin-annotations-3.1.pom"
-    },
-    "org.apache.maven:maven-project:jar:2.0.9": {
-      "layout": "org/apache/maven/maven-project/2.0.9/maven-project-2.0.9.jar",
-      "sha256": "c82db125f53716f59008e3214063869717a976bf857879de6d4092c73cdc7e12",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.9/maven-project-2.0.9.jar"
     },
     "org.apache.maven:maven-model:jar:2.0.6": {
       "layout": "org/apache/maven/maven-model/2.0.6/maven-model-2.0.6.jar",
@@ -415,125 +455,45 @@
       "sha256": "87083dd97721542f2745eede587fbb6cb1aef2b395f46c2bd578c6d9d7b63521",
       "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.9/maven-model-2.0.9.jar"
     },
-    "org.apache.maven:maven-plugin-descriptor:pom:2.0.9": {
-      "layout": "org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9.pom",
-      "sha256": "aa38ab11a2c97f9b61dec56074d59e98f2ea63c0cd7b3b2f61acff6549d064e6",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9.pom"
+    "org.apache.maven:maven-model:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-model/2.0.6/maven-model-2.0.6.pom",
+      "sha256": "e88566fd64906e8e9a2315e5cb67efb7e0f4947a1c45a45cff399f64a235ac1f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.6/maven-model-2.0.6.pom"
     },
-    "org.apache.maven:maven-project:jar:2.0.6": {
-      "layout": "org/apache/maven/maven-project/2.0.6/maven-project-2.0.6.jar",
-      "sha256": "f091ef5587537947a4c6e43cf200c567e1bf44c101443e8f8cf51e2c126e0195",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.6/maven-project-2.0.6.jar"
+    "org.apache.maven:maven-model:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-model/2.0.9/maven-model-2.0.9.pom",
+      "sha256": "2bfc8ce93b46c1bbe8e809197a2f970c5573d2b0d3412c84d7cdfa5961299087",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.9/maven-model-2.0.9.pom"
     },
-    "org.codehaus.plexus:plexus-io:pom:2.0.2": {
-      "layout": "org/codehaus/plexus/plexus-io/2.0.2/plexus-io-2.0.2.pom",
-      "sha256": "67a1ce072ad9ff4ce37985a1c32827eaeda4660cabe7f69eff2ca1ebff2d23bd",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/2.0.2/plexus-io-2.0.2.pom"
+    "org.apache.maven:maven-model:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-model/2.2.1/maven-model-2.2.1.pom",
+      "sha256": "62dd8e35a2c4432bb22f8250bbfe08639635599b4064d5d747bd24cf3c02fac5",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.2.1/maven-model-2.2.1.pom"
     },
-    "org.apache.maven:maven-plugin-descriptor:pom:2.0.6": {
-      "layout": "org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.pom",
-      "sha256": "77ca407ccc76079a2b60f4d3e652c19552890303fa00748623e372eac09039a1",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.pom"
+    "org.apache.maven:maven-monitor:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.jar",
+      "sha256": "47289bc307849383d41eddbe3800f1945b2204ab319b0d38e391f6780c37b4e3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.jar"
     },
-    "org.apache.maven.doxia:doxia-sink-api:jar:1.0-alpha-7": {
-      "layout": "org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7/doxia-sink-api-1.0-alpha-7.jar",
-      "sha256": "37e66f15f348df957538f81f7e10a3fdcf84e5fbd687b2001ee3d6ab4a25aafe",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia-sink-api/1.0-alpha-7/doxia-sink-api-1.0-alpha-7.jar"
+    "org.apache.maven:maven-monitor:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9.jar",
+      "sha256": "69f5fbf13f7e54885b53b5c2c00adb24178e43a6e997c6350a45a7dc287ebd2f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9.jar"
     },
-    "org.sonatype.plexus:plexus-build-api:jar:0.0.4": {
-      "layout": "org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.jar",
-      "sha256": "d2d415ba26078a84e97816fd444361def86dec65a23b4278d95cfb1c285f2649",
-      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.jar"
+    "org.apache.maven:maven-monitor:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.pom",
+      "sha256": "2cfd187d6465c5ad99552da8441d31ff0c1ced1808d2f624dbdb49223d3baa89",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.pom"
     },
-    "org.apache.maven:maven-settings:pom:2.2.1": {
-      "layout": "org/apache/maven/maven-settings/2.2.1/maven-settings-2.2.1.pom",
-      "sha256": "0d25a88a1b1e44801f8912206a40ff249cb5702ee87cf3d243d5213f7bcf534f",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.2.1/maven-settings-2.2.1.pom"
+    "org.apache.maven:maven-monitor:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9.pom",
+      "sha256": "4fe978f252f57c1768d917603127db3b82e98820059b4943ae04b79c5ac79419",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9.pom"
     },
-    "org.codehaus.plexus:plexus-archiver:pom:2.1": {
-      "layout": "org/codehaus/plexus/plexus-archiver/2.1/plexus-archiver-2.1.pom",
-      "sha256": "d2e14a5c6bed6ac4fc27d57f6ba227bb64a96742f71ee3fbafd2c019fa9d4449",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/2.1/plexus-archiver-2.1.pom"
-    },
-    "org.apache.maven.surefire:surefire:pom:2.12.4": {
-      "layout": "org/apache/maven/surefire/surefire/2.12.4/surefire-2.12.4.pom",
-      "sha256": "71aeb7883b53ef63a5f6282f957dcfd09a6891707fe938b85939d814f2247e82",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire/2.12.4/surefire-2.12.4.pom"
-    },
-    "org.apache.maven:maven-parent:pom:22": {
-      "layout": "org/apache/maven/maven-parent/22/maven-parent-22.pom",
-      "sha256": "165a409718070698b4eb18fdfee4325bc3361cbb8e96a35f4669982cd2adb79a",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/22/maven-parent-22.pom"
-    },
-    "org.apache.maven.plugins:maven-jar-plugin:jar:2.4": {
-      "layout": "org/apache/maven/plugins/maven-jar-plugin/2.4/maven-jar-plugin-2.4.jar",
-      "sha256": "1f22f2e528daddbc5d06518c4dbe4d5f4fa6995c8441c702ee5d7d506bb4b4f3",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-jar-plugin/2.4/maven-jar-plugin-2.4.jar"
-    },
-    "org.apache.maven:maven-parent:pom:21": {
-      "layout": "org/apache/maven/maven-parent/21/maven-parent-21.pom",
-      "sha256": "fc45af8911ea307d1b57564eef1f78b69801e9c11a5619e7eb58d5d00ae9db8e",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/21/maven-parent-21.pom"
-    },
-    "org.apache.maven:maven-core:jar:2.0.6": {
-      "layout": "org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.jar",
-      "sha256": "710d56c05add33beadea2f86254223955aca570c15a610f81be07c96c919d7b6",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.6/maven-core-2.0.6.jar"
-    },
-    "org.apache.maven:maven-parent:pom:23": {
-      "layout": "org/apache/maven/maven-parent/23/maven-parent-23.pom",
-      "sha256": "5425501edd9e0bd7b01eca53cc92e06836d24851151304f9c6759e1713541685",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/23/maven-parent-23.pom"
-    },
-    "org.apache.maven:maven-core:jar:2.0.9": {
-      "layout": "org/apache/maven/maven-core/2.0.9/maven-core-2.0.9.jar",
-      "sha256": "da9bdd720f0b1861fe649a2edf8fc0a65e4e2c4a1a05d8d96adbfaa1319f7285",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.0.9/maven-core-2.0.9.jar"
-    },
-    "org.apache.maven:maven-profile:pom:2.2.1": {
-      "layout": "org/apache/maven/maven-profile/2.2.1/maven-profile-2.2.1.pom",
-      "sha256": "d125b3ade9f694ae60ef835f5ae000b6ba35fba8c34bafd8b40a1961375e63fa",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.2.1/maven-profile-2.2.1.pom"
-    },
-    "org.codehaus.plexus:plexus-utils:pom:1.0.4": {
-      "layout": "org/codehaus/plexus/plexus-utils/1.0.4/plexus-utils-1.0.4.pom",
-      "sha256": "36623a9539061d87f078af61ca62c3eacf422eb374641cf8903cdeb759671eb3",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.0.4/plexus-utils-1.0.4.pom"
-    },
-    "commons-logging:commons-logging-api:pom:1.1": {
-      "layout": "commons-logging/commons-logging-api/1.1/commons-logging-api-1.1.pom",
-      "sha256": "69b8be61aa746c7d02acb1b11eb3b57cb22b246780ed71d79764195cbbe3d99d",
-      "url": "https://repo.maven.apache.org/maven2/commons-logging/commons-logging-api/1.1/commons-logging-api-1.1.pom"
-    },
-    "org.apache.maven:maven-plugin-api:pom:2.0.6": {
-      "layout": "org/apache/maven/maven-plugin-api/2.0.6/maven-plugin-api-2.0.6.pom",
-      "sha256": "e5886cbf7478ed0a89d4502cb4b6b4d25095a53b74e07439ec0ab3f793405822",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.6/maven-plugin-api-2.0.6.pom"
-    },
-    "com.google.collections:google-collections:jar:1.0": {
-      "layout": "com/google/collections/google-collections/1.0/google-collections-1.0.jar",
-      "sha256": "81b8d638af0083c4b877099d56aa0fee714485cd2ace1b6a09cab867cadb375d",
-      "url": "https://repo.maven.apache.org/maven2/com/google/collections/google-collections/1.0/google-collections-1.0.jar"
-    },
-    "org.codehaus.plexus:plexus-compiler-api:jar:2.2": {
-      "layout": "org/codehaus/plexus/plexus-compiler-api/2.2/plexus-compiler-api-2.2.jar",
-      "sha256": "b8c7f9f4ea32cee0263d6589bdeb617325edbf6c2930b3d5d1fb5c1442e545d3",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-api/2.2/plexus-compiler-api-2.2.jar"
-    },
-    "org.slf4j:slf4j-jdk14:pom:1.5.6": {
-      "layout": "org/slf4j/slf4j-jdk14/1.5.6/slf4j-jdk14-1.5.6.pom",
-      "sha256": "85f97344eeeed2714eda6f800aa712c1aa7405b0d7f98e207499363f82f37eec",
-      "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-jdk14/1.5.6/slf4j-jdk14-1.5.6.pom"
-    },
-    "org.apache.maven:maven-archiver:jar:2.5": {
-      "layout": "org/apache/maven/maven-archiver/2.5/maven-archiver-2.5.jar",
-      "sha256": "9fd34ed18dc5a49011380e620be86314f9f734193b8fcf85fb11e7b3a3929d6e",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-archiver/2.5/maven-archiver-2.5.jar"
-    },
-    "org.codehaus.plexus:plexus-compiler-manager:jar:2.2": {
-      "layout": "org/codehaus/plexus/plexus-compiler-manager/2.2/plexus-compiler-manager-2.2.jar",
-      "sha256": "e5e201f06eca14b5268ec58003926552aea36b27492da20134c1a00ded6759bb",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-manager/2.2/plexus-compiler-manager-2.2.jar"
+    "org.apache.maven:maven-monitor:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-monitor/2.2.1/maven-monitor-2.2.1.pom",
+      "sha256": "bc962d48dcebb463c1071004015c4609516d616e884ce36eb7390f9a8095a65b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.2.1/maven-monitor-2.2.1.pom"
     },
     "org.apache.maven:maven-parent:pom:11": {
       "layout": "org/apache/maven/maven-parent/11/maven-parent-11.pom",
@@ -545,105 +505,215 @@
       "sha256": "72d02bac812c6f1e83bb69801b163ac61aa2069b0cceedd90adbab8038deaada",
       "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/13/maven-parent-13.pom"
     },
-    "org.apache.maven.reporting:maven-reporting:pom:2.0.6": {
-      "layout": "org/apache/maven/reporting/maven-reporting/2.0.6/maven-reporting-2.0.6.pom",
-      "sha256": "ab803be997ac806ee7f2e179ad3cda640345ed8fc911082b1f80202c7fc463a4",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting/2.0.6/maven-reporting-2.0.6.pom"
+    "org.apache.maven:maven-parent:pom:21": {
+      "layout": "org/apache/maven/maven-parent/21/maven-parent-21.pom",
+      "sha256": "fc45af8911ea307d1b57564eef1f78b69801e9c11a5619e7eb58d5d00ae9db8e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/21/maven-parent-21.pom"
     },
-    "org.apache.xbean:xbean-reflect:pom:3.4": {
-      "layout": "org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.pom",
-      "sha256": "01c97d4286dd3b5e5441faac3abb589f1fe123cea138bb4ae0995ffae14938df",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.pom"
+    "org.apache.maven:maven-parent:pom:22": {
+      "layout": "org/apache/maven/maven-parent/22/maven-parent-22.pom",
+      "sha256": "165a409718070698b4eb18fdfee4325bc3361cbb8e96a35f4669982cd2adb79a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/22/maven-parent-22.pom"
     },
-    "commons-lang:commons-lang:jar:2.1": {
-      "layout": "commons-lang/commons-lang/2.1/commons-lang-2.1.jar",
-      "sha256": "2ded7343dc8e57decd5e6302337139be020fdd885a2935925e8d575975e480b9",
-      "url": "https://repo.maven.apache.org/maven2/commons-lang/commons-lang/2.1/commons-lang-2.1.jar"
+    "org.apache.maven:maven-parent:pom:23": {
+      "layout": "org/apache/maven/maven-parent/23/maven-parent-23.pom",
+      "sha256": "5425501edd9e0bd7b01eca53cc92e06836d24851151304f9c6759e1713541685",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/23/maven-parent-23.pom"
     },
-    "org.apache.maven.shared:maven-common-artifact-filters:jar:1.3": {
-      "layout": "org/apache/maven/shared/maven-common-artifact-filters/1.3/maven-common-artifact-filters-1.3.jar",
-      "sha256": "eabb4ba67917a8d5762f35f35314105bac2265588295c6b77a4feac9d210a336",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/1.3/maven-common-artifact-filters-1.3.jar"
+    "org.apache.maven:maven-parent:pom:5": {
+      "layout": "org/apache/maven/maven-parent/5/maven-parent-5.pom",
+      "sha256": "5d7c2a229173155823c45380332f221bf0d27e52c9db76e9217940306765bd50",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/5/maven-parent-5.pom"
     },
-    "classworlds:classworlds:pom:1.1-alpha-2": {
-      "layout": "classworlds/classworlds/1.1-alpha-2/classworlds-1.1-alpha-2.pom",
-      "sha256": "0cc647963b74ad1d7a37c9868e9e5a8f474e49297e1863582253a08a4c719cb1",
-      "url": "https://repo.maven.apache.org/maven2/classworlds/classworlds/1.1-alpha-2/classworlds-1.1-alpha-2.pom"
+    "org.apache.maven:maven-parent:pom:8": {
+      "layout": "org/apache/maven/maven-parent/8/maven-parent-8.pom",
+      "sha256": "3cb6712f827c80dc6b0b0b967776dba451c023a92b7741bba45d23ab7a83281a",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/8/maven-parent-8.pom"
     },
-    "org.apache.maven:maven-repository-metadata:pom:2.2.1": {
-      "layout": "org/apache/maven/maven-repository-metadata/2.2.1/maven-repository-metadata-2.2.1.pom",
-      "sha256": "9dad0f56523955b60a9903f4e8342891355d7a59c77f36a3b53cf6ff2e4df625",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.2.1/maven-repository-metadata-2.2.1.pom"
+    "org.apache.maven:maven-plugin-api:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-plugin-api/2.0.6/maven-plugin-api-2.0.6.jar",
+      "sha256": "a1b54bbe38d25ccd3179c5563156b3b0c0ecd014647c3ebaeba8e92b2e2e5053",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.6/maven-plugin-api-2.0.6.jar"
     },
-    "org.codehaus.plexus:plexus-utils:jar:3.0.8": {
-      "layout": "org/codehaus/plexus/plexus-utils/3.0.8/plexus-utils-3.0.8.jar",
-      "sha256": "6c040032841fe6b23612c7a4b52347a4a115fdde748086c399a154b4b108e56b",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0.8/plexus-utils-3.0.8.jar"
+    "org.apache.maven:maven-plugin-api:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9.jar",
+      "sha256": "f1e4b0af3079cc0db361eab9429a3cda7b118cd032211c7e61b3805a62bfde1f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9.jar"
     },
-    "org.apache.maven.shared:maven-shared-utils:pom:0.1": {
-      "layout": "org/apache/maven/shared/maven-shared-utils/0.1/maven-shared-utils-0.1.pom",
-      "sha256": "9ecb36b0e0d7d1d0f0dabd8705368b710df58b943091e9fa9071a29ccdc15a33",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/0.1/maven-shared-utils-0.1.pom"
+    "org.apache.maven:maven-plugin-api:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-plugin-api/2.0.6/maven-plugin-api-2.0.6.pom",
+      "sha256": "e5886cbf7478ed0a89d4502cb4b6b4d25095a53b74e07439ec0ab3f793405822",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.6/maven-plugin-api-2.0.6.pom"
     },
-    "org.apache.maven.surefire:surefire-booter:jar:2.12.4": {
-      "layout": "org/apache/maven/surefire/surefire-booter/2.12.4/surefire-booter-2.12.4.jar",
-      "sha256": "ad03864f1373c48da45ea25570e4950cd144fea7c08bd040f82f524ea4e1047f",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-booter/2.12.4/surefire-booter-2.12.4.jar"
+    "org.apache.maven:maven-plugin-api:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9.pom",
+      "sha256": "0ef1a886c795b5ca48d08245b13d1128ecbc6fd0f05e6556749547df9978680b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9.pom"
     },
-    "org.apache.maven:maven-monitor:pom:2.2.1": {
-      "layout": "org/apache/maven/maven-monitor/2.2.1/maven-monitor-2.2.1.pom",
-      "sha256": "bc962d48dcebb463c1071004015c4609516d616e884ce36eb7390f9a8095a65b",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.2.1/maven-monitor-2.2.1.pom"
+    "org.apache.maven:maven-plugin-api:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-plugin-api/2.2.1/maven-plugin-api-2.2.1.pom",
+      "sha256": "c10d0460c2d5c5076304598965991d6257d1bf31bdef921a17ce3d059bce654e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.2.1/maven-plugin-api-2.2.1.pom"
     },
-    "org.codehaus.plexus:plexus-containers:pom:1.0.3": {
-      "layout": "org/codehaus/plexus/plexus-containers/1.0.3/plexus-containers-1.0.3.pom",
-      "sha256": "7c75075badcb014443ee94c8c4cad2f4a9905be3ce9430fe7b220afc7fa3a80f",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.0.3/plexus-containers-1.0.3.pom"
+    "org.apache.maven:maven-plugin-descriptor:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.jar",
+      "sha256": "e6e99e03921e576358e24a797e3034d0587ad08dac8ebf78b3fcf3e1a96a37d9",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.jar"
     },
-    "org.apache.maven:maven-plugin-registry:jar:2.0.9": {
-      "layout": "org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9.jar",
-      "sha256": "5e6cc5d0501c8d9b9abf9605283e95733b9428c9033a079502cd4d97cd0c490e",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9.jar"
+    "org.apache.maven:maven-plugin-descriptor:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9.jar",
+      "sha256": "d4b0d72958125b6cedc12c7ed5c50a20624e1e57ee37d622fb67f30dcf0327b3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9.jar"
     },
-    "org.apache.maven:maven-plugin-registry:pom:2.2.1": {
-      "layout": "org/apache/maven/maven-plugin-registry/2.2.1/maven-plugin-registry-2.2.1.pom",
-      "sha256": "3db15325cd620c0e54c3d88b6b7ec1bac43db376e18c9bf56bd0c05402ee6be8",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.2.1/maven-plugin-registry-2.2.1.pom"
+    "org.apache.maven:maven-plugin-descriptor:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.pom",
+      "sha256": "77ca407ccc76079a2b60f4d3e652c19552890303fa00748623e372eac09039a1",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.pom"
     },
-    "org.sonatype.spice:spice-parent:pom:16": {
-      "layout": "org/sonatype/spice/spice-parent/16/spice-parent-16.pom",
-      "sha256": "258f43b5e805687302a5bb400856b972a573ec42a44f949641354a84b9243758",
-      "url": "https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/16/spice-parent-16.pom"
+    "org.apache.maven:maven-plugin-descriptor:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9.pom",
+      "sha256": "aa38ab11a2c97f9b61dec56074d59e98f2ea63c0cd7b3b2f61acff6549d064e6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9.pom"
     },
-    "org.sonatype.spice:spice-parent:pom:17": {
-      "layout": "org/sonatype/spice/spice-parent/17/spice-parent-17.pom",
-      "sha256": "9151f9a5b33ec36ee8778842fc56144fb0242d39cbcc42061b053b8909969bdf",
-      "url": "https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/17/spice-parent-17.pom"
+    "org.apache.maven:maven-plugin-descriptor:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-plugin-descriptor/2.2.1/maven-plugin-descriptor-2.2.1.pom",
+      "sha256": "d4ef608f90dc9599c0cc325ca2ccc2e1ceb439b3d2ff31ae22e30ac1a63a68f0",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.2.1/maven-plugin-descriptor-2.2.1.pom"
     },
-    "org.apache:apache:pom:3": {
-      "layout": "org/apache/apache/3/apache-3.pom",
-      "sha256": "393c50afb4b7aa6eb57e5377a55a1a0610b19f75b52ece01308db04a1187a20e",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/3/apache-3.pom"
+    "org.apache.maven:maven-plugin-parameter-documenter:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.jar",
+      "sha256": "b5f0dd177264a6e25ce0ed8724f8b6f3bca48b215b9ff4576e1bec7b0773f9e8",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.jar"
+    },
+    "org.apache.maven:maven-plugin-parameter-documenter:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9.jar",
+      "sha256": "3be9db19335747e8a22f768fab3539992a66d280ccff5f8cd487cada733aee98",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9.jar"
+    },
+    "org.apache.maven:maven-plugin-parameter-documenter:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.pom",
+      "sha256": "b5b53025b13fa0013ae2caede21f9af4215c25279db4ee0a1f943aaa8815c174",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.pom"
+    },
+    "org.apache.maven:maven-plugin-parameter-documenter:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9.pom",
+      "sha256": "3d356e97c1ab8c5673e8908b07e1e50d842dab8cbea8a2082f87016b891f91a6",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9.pom"
+    },
+    "org.apache.maven:maven-plugin-parameter-documenter:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-plugin-parameter-documenter/2.2.1/maven-plugin-parameter-documenter-2.2.1.pom",
+      "sha256": "902b0160f7b81ec76452468f8ae087fc1cfefc08367c84d9197512dfb01d845d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.2.1/maven-plugin-parameter-documenter-2.2.1.pom"
     },
     "org.apache.maven:maven-plugin-registry:jar:2.0.6": {
       "layout": "org/apache/maven/maven-plugin-registry/2.0.6/maven-plugin-registry-2.0.6.jar",
       "sha256": "98d6f3fbd17a67736d65e9c4ee484c5d6bc54589042e7cd3db65f87d91070f2a",
       "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0.6/maven-plugin-registry-2.0.6.jar"
     },
-    "org.apache:apache:pom:4": {
-      "layout": "org/apache/apache/4/apache-4.pom",
-      "sha256": "9e9323a26ba8eb2394efef0c96d31b70df570808630dc147cab1e73541cc5194",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/4/apache-4.pom"
+    "org.apache.maven:maven-plugin-registry:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9.jar",
+      "sha256": "5e6cc5d0501c8d9b9abf9605283e95733b9428c9033a079502cd4d97cd0c490e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9.jar"
     },
-    "org.apache.maven:maven-artifact-manager:pom:2.0.6": {
-      "layout": "org/apache/maven/maven-artifact-manager/2.0.6/maven-artifact-manager-2.0.6.pom",
-      "sha256": "a80884dfac999ebdda57904f929a14f28ab08e5411d515bdb1fbdaacf0ed6d6f",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.6/maven-artifact-manager-2.0.6.pom"
+    "org.apache.maven:maven-plugin-registry:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-plugin-registry/2.0.6/maven-plugin-registry-2.0.6.pom",
+      "sha256": "cf633e8cde33e65580776d845756d332d24f7c6d5bf9ae90fc6c43d73cb5fe23",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0.6/maven-plugin-registry-2.0.6.pom"
     },
-    "org.apache:apache:pom:5": {
-      "layout": "org/apache/apache/5/apache-5.pom",
-      "sha256": "1933a6037439b389bda2feaccfc0113880fd8d88f7d240d2052b91108dd5ae89",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/5/apache-5.pom"
+    "org.apache.maven:maven-plugin-registry:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9.pom",
+      "sha256": "7de23d8212885031dc2e6fabc327957ff8324563a8fbeb10b0a85b498b826667",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.0.9/maven-plugin-registry-2.0.9.pom"
+    },
+    "org.apache.maven:maven-plugin-registry:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-plugin-registry/2.2.1/maven-plugin-registry-2.2.1.pom",
+      "sha256": "3db15325cd620c0e54c3d88b6b7ec1bac43db376e18c9bf56bd0c05402ee6be8",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-registry/2.2.1/maven-plugin-registry-2.2.1.pom"
+    },
+    "org.apache.maven:maven-profile:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-profile/2.0.6/maven-profile-2.0.6.jar",
+      "sha256": "89c07a73ea3b41e6c3c7e126871c898f1741fbfddd35633f9524fda09c25dc01",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.6/maven-profile-2.0.6.jar"
+    },
+    "org.apache.maven:maven-profile:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9.jar",
+      "sha256": "88fe952eaf4e28da0533ceef5d8e9b7fc9f09f7f825ab342130bf4b8c3805664",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9.jar"
+    },
+    "org.apache.maven:maven-profile:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-profile/2.0.6/maven-profile-2.0.6.pom",
+      "sha256": "09455abf6ab86671fab0ae5bba8293c17382c8a9c53fafc3befb3e0720f2b707",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.6/maven-profile-2.0.6.pom"
+    },
+    "org.apache.maven:maven-profile:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9.pom",
+      "sha256": "3be51b8a7e080ae0a765e870fa8c3acaab2a916ec24cbf0bb468d5d8abcbc104",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.0.9/maven-profile-2.0.9.pom"
+    },
+    "org.apache.maven:maven-profile:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-profile/2.2.1/maven-profile-2.2.1.pom",
+      "sha256": "d125b3ade9f694ae60ef835f5ae000b6ba35fba8c34bafd8b40a1961375e63fa",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-profile/2.2.1/maven-profile-2.2.1.pom"
+    },
+    "org.apache.maven:maven-project:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-project/2.0.6/maven-project-2.0.6.jar",
+      "sha256": "f091ef5587537947a4c6e43cf200c567e1bf44c101443e8f8cf51e2c126e0195",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.6/maven-project-2.0.6.jar"
+    },
+    "org.apache.maven:maven-project:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-project/2.0.9/maven-project-2.0.9.jar",
+      "sha256": "c82db125f53716f59008e3214063869717a976bf857879de6d4092c73cdc7e12",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.9/maven-project-2.0.9.jar"
+    },
+    "org.apache.maven:maven-project:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-project/2.0.6/maven-project-2.0.6.pom",
+      "sha256": "7dd6468c154d99c39a94c7a8c734aa96366864334b6b2ea10778459860cbe3e5",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.6/maven-project-2.0.6.pom"
+    },
+    "org.apache.maven:maven-project:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-project/2.0.9/maven-project-2.0.9.pom",
+      "sha256": "fa8043afdbe232e7541b965386dc582be336783ac220aadc9bde401b02295a90",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.0.9/maven-project-2.0.9.pom"
+    },
+    "org.apache.maven:maven-project:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-project/2.2.1/maven-project-2.2.1.pom",
+      "sha256": "34af0baedaef19375b7c1a7da967e9089d5e0754647fdbe9a302590392874b77",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.2.1/maven-project-2.2.1.pom"
+    },
+    "org.apache.maven:maven-repository-metadata:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-repository-metadata/2.0.6/maven-repository-metadata-2.0.6.jar",
+      "sha256": "dce817d7c4229d5e666247c05853ef8ad7ac1b72d27953501c4a1ea739f67b25",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.6/maven-repository-metadata-2.0.6.jar"
+    },
+    "org.apache.maven:maven-repository-metadata:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9.jar",
+      "sha256": "2c302f060de887716be438e0eb0c3d89d7ece213631882446ee0b19880c00dbd",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9.jar"
+    },
+    "org.apache.maven:maven-repository-metadata:pom:2.0.6": {
+      "layout": "org/apache/maven/maven-repository-metadata/2.0.6/maven-repository-metadata-2.0.6.pom",
+      "sha256": "df10657745e39010954fd009276b65b75198bdc40d0adb9916f9697c71fcd986",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.6/maven-repository-metadata-2.0.6.pom"
+    },
+    "org.apache.maven:maven-repository-metadata:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9.pom",
+      "sha256": "0447b3919bc7d0301b763852aca8dc0e87ccfbe34a4d5257f7f4fae8a4e87998",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9.pom"
+    },
+    "org.apache.maven:maven-repository-metadata:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-repository-metadata/2.2.1/maven-repository-metadata-2.2.1.pom",
+      "sha256": "9dad0f56523955b60a9903f4e8342891355d7a59c77f36a3b53cf6ff2e4df625",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.2.1/maven-repository-metadata-2.2.1.pom"
+    },
+    "org.apache.maven:maven-settings:jar:2.0.6": {
+      "layout": "org/apache/maven/maven-settings/2.0.6/maven-settings-2.0.6.jar",
+      "sha256": "bb7af11f28a37d21bf20e11705c78aa4adce3aaff1b9b981c031c6be1aa0ec97",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0.6/maven-settings-2.0.6.jar"
+    },
+    "org.apache.maven:maven-settings:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9.jar",
+      "sha256": "1e5c98ebc4b9ae1f2c8d843c1dd9701a1c25b9afaff143c3e1fa4d90c22850fe",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9.jar"
     },
     "org.apache.maven:maven-settings:pom:2.0.6": {
       "layout": "org/apache/maven/maven-settings/2.0.6/maven-settings-2.0.6.pom",
@@ -655,70 +725,355 @@
       "sha256": "672f22f9b697784518b8b84719324013a8f1bf0337f1d3059b83982d4ca480ca",
       "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9.pom"
     },
-    "org.codehaus.plexus:plexus-utils:jar:1.5.1": {
-      "layout": "org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1.jar",
-      "sha256": "72582f8ba285601fa753ceeda73ff3cbd94c6e78f52ec611621eaa0186165452",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1.jar"
+    "org.apache.maven:maven-settings:pom:2.2.1": {
+      "layout": "org/apache/maven/maven-settings/2.2.1/maven-settings-2.2.1.pom",
+      "sha256": "0d25a88a1b1e44801f8912206a40ff249cb5702ee87cf3d243d5213f7bcf534f",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.2.1/maven-settings-2.2.1.pom"
     },
-    "org.sonatype.spice:spice-parent:pom:10": {
-      "layout": "org/sonatype/spice/spice-parent/10/spice-parent-10.pom",
-      "sha256": "683c012c6bf5e1e31b232b3755c027ccd829692a09c8216652b414b09d4ae623",
-      "url": "https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/10/spice-parent-10.pom"
+    "org.apache.maven:maven-toolchain:jar:1.0": {
+      "layout": "org/apache/maven/maven-toolchain/1.0/maven-toolchain-1.0.jar",
+      "sha256": "95730d85b872517036b12ef7d474e72f2467f09ae40006169570450e6de6ac95",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/1.0/maven-toolchain-1.0.jar"
     },
-    "org.sonatype.spice:spice-parent:pom:12": {
-      "layout": "org/sonatype/spice/spice-parent/12/spice-parent-12.pom",
-      "sha256": "21a19b26dbe5c38ddb5114cf4eadbf5ccb411bc6b128fdd5949b1ccb12f3683e",
-      "url": "https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/12/spice-parent-12.pom"
+    "org.apache.maven:maven-toolchain:jar:2.0.9": {
+      "layout": "org/apache/maven/maven-toolchain/2.0.9/maven-toolchain-2.0.9.jar",
+      "sha256": "dcbddf7cbc3bb03f76afdeb598491ae815620c5ff66cf8f18d7239d1dc764dc8",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/2.0.9/maven-toolchain-2.0.9.jar"
     },
-    "org.apache.maven.shared:maven-shared-incremental:jar:1.1": {
-      "layout": "org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.jar",
-      "sha256": "61988e54486a5dc38f06c70fdae5b108556c63bd433697b9f4305fcdb30fa40e",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.jar"
+    "org.apache.maven:maven-toolchain:pom:1.0": {
+      "layout": "org/apache/maven/maven-toolchain/1.0/maven-toolchain-1.0.pom",
+      "sha256": "665a0be425b12cc6938a41f7ebde2c4c7c23b02b3826344462001057449d503d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/1.0/maven-toolchain-1.0.pom"
     },
-    "org.apache.maven.plugin-tools:maven-plugin-annotations:jar:3.1": {
-      "layout": "org/apache/maven/plugin-tools/maven-plugin-annotations/3.1/maven-plugin-annotations-3.1.jar",
-      "sha256": "8de51faf9303a49a479e8fd01608166a035f16d259086c84f62afdae2c18617b",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugin-tools/maven-plugin-annotations/3.1/maven-plugin-annotations-3.1.jar"
+    "org.apache.maven:maven-toolchain:pom:2.0.9": {
+      "layout": "org/apache/maven/maven-toolchain/2.0.9/maven-toolchain-2.0.9.pom",
+      "sha256": "7fca590bc5f4b4841c3a00dade5fb9e1f454f178e45e5e4165304e7ce1be35dc",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/2.0.9/maven-toolchain-2.0.9.pom"
     },
-    "org.apache.maven.surefire:maven-surefire-common:jar:2.12.4": {
-      "layout": "org/apache/maven/surefire/maven-surefire-common/2.12.4/maven-surefire-common-2.12.4.jar",
-      "sha256": "5fa774434507bea2edcf4496536c88f883926cc6baf121b5af172fa494aaa30d",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/2.12.4/maven-surefire-common-2.12.4.jar"
+    "org.apache.maven:maven:pom:2.0.6": {
+      "layout": "org/apache/maven/maven/2.0.6/maven-2.0.6.pom",
+      "sha256": "f5755c01058f048c61c3baf11e03c605b9c0ec1021ab40a3dcb76fb5bf51ff34",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.0.6/maven-2.0.6.pom"
     },
-    "org.apache.maven.shared:maven-shared-utils:jar:0.1": {
-      "layout": "org/apache/maven/shared/maven-shared-utils/0.1/maven-shared-utils-0.1.jar",
-      "sha256": "86cd563b0bb40b0ef4e7183e41768049ad0afaca5b5acbf9680c53c217ca93d7",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/0.1/maven-shared-utils-0.1.jar"
+    "org.apache.maven:maven:pom:2.0.9": {
+      "layout": "org/apache/maven/maven/2.0.9/maven-2.0.9.pom",
+      "sha256": "6db25755b962d443bd7698b87654f336de43fd5319cbcc000e2e72c08c3619b4",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.0.9/maven-2.0.9.pom"
     },
-    "org.apache.maven:maven-artifact-manager:pom:2.0.9": {
-      "layout": "org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9.pom",
-      "sha256": "d573bbb1b78c76523c45aba2859d390883b932dfde67e3c2032fc443c0fa098d",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.0.9/maven-artifact-manager-2.0.9.pom"
+    "org.apache.maven:maven:pom:2.2.1": {
+      "layout": "org/apache/maven/maven/2.2.1/maven-2.2.1.pom",
+      "sha256": "d135cff96dcbbc8a5fab30180e557cae620373cf26941d4c738a88896a2d98ed",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.2.1/maven-2.2.1.pom"
+    },
+    "org.apache.xbean:xbean-reflect:jar:3.4": {
+      "layout": "org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.jar",
+      "sha256": "17e0efa187127034623197fb88c50c30d3baa62baa0f07d6ec693047ac92ec3b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.jar"
+    },
+    "org.apache.xbean:xbean-reflect:pom:3.4": {
+      "layout": "org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.pom",
+      "sha256": "01c97d4286dd3b5e5441faac3abb589f1fe123cea138bb4ae0995ffae14938df",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean-reflect/3.4/xbean-reflect-3.4.pom"
+    },
+    "org.apache.xbean:xbean:pom:3.4": {
+      "layout": "org/apache/xbean/xbean/3.4/xbean-3.4.pom",
+      "sha256": "56ab9c6c2d022a9b7079006ba500a996cd2c21411d53cac524933af20c5a4b99",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean/3.4/xbean-3.4.pom"
+    },
+    "org.apache:apache:pom:10": {
+      "layout": "org/apache/apache/10/apache-10.pom",
+      "sha256": "802feece72852dafcbd0a425a60367c72c5cb9b6ea5aae59481128569189daf9",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/10/apache-10.pom"
+    },
+    "org.apache:apache:pom:11": {
+      "layout": "org/apache/apache/11/apache-11.pom",
+      "sha256": "9a4fb5addb41d8116b6441e9e3c48764d9cc562243d5608652bea6db0509297b",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/11/apache-11.pom"
+    },
+    "org.apache:apache:pom:13": {
+      "layout": "org/apache/apache/13/apache-13.pom",
+      "sha256": "ff513db0361fd41237bef4784968bc15aae478d4ec0a9496f811072ccaf3841d",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/13/apache-13.pom"
+    },
+    "org.apache:apache:pom:3": {
+      "layout": "org/apache/apache/3/apache-3.pom",
+      "sha256": "393c50afb4b7aa6eb57e5377a55a1a0610b19f75b52ece01308db04a1187a20e",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/3/apache-3.pom"
+    },
+    "org.apache:apache:pom:4": {
+      "layout": "org/apache/apache/4/apache-4.pom",
+      "sha256": "9e9323a26ba8eb2394efef0c96d31b70df570808630dc147cab1e73541cc5194",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/4/apache-4.pom"
+    },
+    "org.apache:apache:pom:5": {
+      "layout": "org/apache/apache/5/apache-5.pom",
+      "sha256": "1933a6037439b389bda2feaccfc0113880fd8d88f7d240d2052b91108dd5ae89",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/5/apache-5.pom"
+    },
+    "org.apache:apache:pom:6": {
+      "layout": "org/apache/apache/6/apache-6.pom",
+      "sha256": "12edb5096e13f40c362d0bd40902589fa9586505123fa26799ce50b116fa5bb3",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/6/apache-6.pom"
+    },
+    "org.apache:apache:pom:9": {
+      "layout": "org/apache/apache/9/apache-9.pom",
+      "sha256": "4946e60a547c8eda69f3bc23c5b6f0dadcf8469ea49b1d1da7de34aecfcf18dd",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/9/apache-9.pom"
+    },
+    "org.codehaus.plexus:plexus-archiver:jar:2.1": {
+      "layout": "org/codehaus/plexus/plexus-archiver/2.1/plexus-archiver-2.1.jar",
+      "sha256": "5a49a4c13e29da41c24bbb35b2f94b82bde259e25d4dd55ee3159e31d20677b8",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/2.1/plexus-archiver-2.1.jar"
+    },
+    "org.codehaus.plexus:plexus-archiver:pom:2.1": {
+      "layout": "org/codehaus/plexus/plexus-archiver/2.1/plexus-archiver-2.1.pom",
+      "sha256": "d2e14a5c6bed6ac4fc27d57f6ba227bb64a96742f71ee3fbafd2c019fa9d4449",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-archiver/2.1/plexus-archiver-2.1.pom"
+    },
+    "org.codehaus.plexus:plexus-classworlds:jar:2.2.2": {
+      "layout": "org/codehaus/plexus/plexus-classworlds/2.2.2/plexus-classworlds-2.2.2.jar",
+      "sha256": "13a90763640e445ffa432ce9586e416572645c3ed4db6a860fe0d28256ad40ce",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.2.2/plexus-classworlds-2.2.2.jar"
+    },
+    "org.codehaus.plexus:plexus-classworlds:pom:2.2.2": {
+      "layout": "org/codehaus/plexus/plexus-classworlds/2.2.2/plexus-classworlds-2.2.2.pom",
+      "sha256": "6aad43eb7fee989d50f1ecaf4a8030c708f9c9ea3eb72ee023d76746ff89570a",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.2.2/plexus-classworlds-2.2.2.pom"
+    },
+    "org.codehaus.plexus:plexus-compiler-api:jar:2.2": {
+      "layout": "org/codehaus/plexus/plexus-compiler-api/2.2/plexus-compiler-api-2.2.jar",
+      "sha256": "b8c7f9f4ea32cee0263d6589bdeb617325edbf6c2930b3d5d1fb5c1442e545d3",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-api/2.2/plexus-compiler-api-2.2.jar"
     },
     "org.codehaus.plexus:plexus-compiler-api:pom:2.2": {
       "layout": "org/codehaus/plexus/plexus-compiler-api/2.2/plexus-compiler-api-2.2.pom",
       "sha256": "c50bb4169e2ae41d184b6507839100033bf6e86f54828829038aa0f7c8e89aa3",
       "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-api/2.2/plexus-compiler-api-2.2.pom"
     },
-    "org.apache.maven:maven-plugin-descriptor:pom:2.2.1": {
-      "layout": "org/apache/maven/maven-plugin-descriptor/2.2.1/maven-plugin-descriptor-2.2.1.pom",
-      "sha256": "d4ef608f90dc9599c0cc325ca2ccc2e1ceb439b3d2ff31ae22e30ac1a63a68f0",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.2.1/maven-plugin-descriptor-2.2.1.pom"
+    "org.codehaus.plexus:plexus-compiler-javac:jar:2.2": {
+      "layout": "org/codehaus/plexus/plexus-compiler-javac/2.2/plexus-compiler-javac-2.2.jar",
+      "sha256": "03344d155153620b4de75d322d1b422701ac827dd0c631def1c7f46abf81386d",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-javac/2.2/plexus-compiler-javac-2.2.jar"
     },
-    "org.codehaus.plexus:plexus:pom:2.0.6": {
-      "layout": "org/codehaus/plexus/plexus/2.0.6/plexus-2.0.6.pom",
-      "sha256": "bea12e747708d25e73410ca1c731ebdfa102e8bdb6ec7d81bd4522583b234bcc",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/2.0.6/plexus-2.0.6.pom"
+    "org.codehaus.plexus:plexus-compiler-javac:pom:2.2": {
+      "layout": "org/codehaus/plexus/plexus-compiler-javac/2.2/plexus-compiler-javac-2.2.pom",
+      "sha256": "18a41342ece8d3016b4b5ec3e84b52331420413a17ce298574c1f61e26733955",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-javac/2.2/plexus-compiler-javac-2.2.pom"
     },
-    "org.codehaus.plexus:plexus:pom:2.0.7": {
-      "layout": "org/codehaus/plexus/plexus/2.0.7/plexus-2.0.7.pom",
-      "sha256": "2b59062030ab0a15c5d0977ba22421706368926488739a65f25793e715cc8a74",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/2.0.7/plexus-2.0.7.pom"
+    "org.codehaus.plexus:plexus-compiler-manager:jar:2.2": {
+      "layout": "org/codehaus/plexus/plexus-compiler-manager/2.2/plexus-compiler-manager-2.2.jar",
+      "sha256": "e5e201f06eca14b5268ec58003926552aea36b27492da20134c1a00ded6759bb",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-manager/2.2/plexus-compiler-manager-2.2.jar"
     },
-    "classworlds:classworlds:jar:1.1": {
-      "layout": "classworlds/classworlds/1.1/classworlds-1.1.jar",
-      "sha256": "4e3e0ad158ec60917e0de544c550f31cd65d5a97c3af1c1968bf427e4a9df2e4",
-      "url": "https://repo.maven.apache.org/maven2/classworlds/classworlds/1.1/classworlds-1.1.jar"
+    "org.codehaus.plexus:plexus-compiler-manager:pom:2.2": {
+      "layout": "org/codehaus/plexus/plexus-compiler-manager/2.2/plexus-compiler-manager-2.2.pom",
+      "sha256": "bf2aedb6f801096d0b7f9db201fef9ceb0696b801c446ada188144cae4e91dd2",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-manager/2.2/plexus-compiler-manager-2.2.pom"
+    },
+    "org.codehaus.plexus:plexus-compiler:pom:2.2": {
+      "layout": "org/codehaus/plexus/plexus-compiler/2.2/plexus-compiler-2.2.pom",
+      "sha256": "1d94e9a3f048c9eaaba0016ea188a4e7029c6849b8708ff6dc900a34fe03c28c",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler/2.2/plexus-compiler-2.2.pom"
+    },
+    "org.codehaus.plexus:plexus-compilers:pom:2.2": {
+      "layout": "org/codehaus/plexus/plexus-compilers/2.2/plexus-compilers-2.2.pom",
+      "sha256": "f6c8d1ee6e02ecd7376346b3f526e90b9e2c4d6128efa3b33cd463bcef8d480a",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compilers/2.2/plexus-compilers-2.2.pom"
+    },
+    "org.codehaus.plexus:plexus-component-annotations:jar:1.5.5": {
+      "layout": "org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar",
+      "sha256": "4df7a6a7be64b35bbccf60b5c115697f9ea3421d22674ae67135dde375fcca1f",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar"
+    },
+    "org.codehaus.plexus:plexus-component-annotations:pom:1.5.5": {
+      "layout": "org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.pom",
+      "sha256": "815f3ec316b8c5fa701385fdf4009bfb51e07d780e8f6a6e2afe720c52d7e292",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.pom"
+    },
+    "org.codehaus.plexus:plexus-components:pom:1.1.14": {
+      "layout": "org/codehaus/plexus/plexus-components/1.1.14/plexus-components-1.1.14.pom",
+      "sha256": "381d72c526be217b770f9f8c3f749a86d3b1548ac5c1fcb48d267530ec60d43f",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.14/plexus-components-1.1.14.pom"
+    },
+    "org.codehaus.plexus:plexus-components:pom:1.1.15": {
+      "layout": "org/codehaus/plexus/plexus-components/1.1.15/plexus-components-1.1.15.pom",
+      "sha256": "7940cd305323b8409fdb7e78398f6efd8ff8a642c7dd8f353e519abe91ab0da3",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.15/plexus-components-1.1.15.pom"
+    },
+    "org.codehaus.plexus:plexus-components:pom:1.1.19": {
+      "layout": "org/codehaus/plexus/plexus-components/1.1.19/plexus-components-1.1.19.pom",
+      "sha256": "d3e7f3adf5d002c01f362760ad1c2dce98e6354009a7c07c0a105c3eccb17159",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.1.19/plexus-components-1.1.19.pom"
+    },
+    "org.codehaus.plexus:plexus-components:pom:1.3.1": {
+      "layout": "org/codehaus/plexus/plexus-components/1.3.1/plexus-components-1.3.1.pom",
+      "sha256": "8cbcb2aacd7f4a7759866ce91b2f910310fbe5a586b5fc7b9bdb76af9257e7c4",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-components/1.3.1/plexus-components-1.3.1.pom"
+    },
+    "org.codehaus.plexus:plexus-container-default:jar:1.0-alpha-9-stable-1": {
+      "layout": "org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.jar",
+      "sha256": "7c758612888782ccfe376823aee7cdcc7e0cdafb097f7ef50295a0b0c3a16edf",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.jar"
+    },
+    "org.codehaus.plexus:plexus-container-default:jar:1.5.5": {
+      "layout": "org/codehaus/plexus/plexus-container-default/1.5.5/plexus-container-default-1.5.5.jar",
+      "sha256": "69197486cd80beb54b4e0fcabaa325ec2d4e2636e9b245c472435c87a10931cf",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.5.5/plexus-container-default-1.5.5.jar"
+    },
+    "org.codehaus.plexus:plexus-container-default:pom:1.0-alpha-9": {
+      "layout": "org/codehaus/plexus/plexus-container-default/1.0-alpha-9/plexus-container-default-1.0-alpha-9.pom",
+      "sha256": "8864b08e353614d0c4111f455f8b3907179f8b0be6c0845bc7f31ef6daf206ec",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-9/plexus-container-default-1.0-alpha-9.pom"
+    },
+    "org.codehaus.plexus:plexus-container-default:pom:1.0-alpha-9-stable-1": {
+      "layout": "org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.pom",
+      "sha256": "ef71d45a49edfe76be0f520312a76bc2aae73ec0743a5ffffe10d30122c6e2b2",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.pom"
+    },
+    "org.codehaus.plexus:plexus-container-default:pom:1.5.5": {
+      "layout": "org/codehaus/plexus/plexus-container-default/1.5.5/plexus-container-default-1.5.5.pom",
+      "sha256": "3f0dc324ff65ccdbd6bb3df39136e2878047a2b0c19799689bcefa4132bdcba4",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.5.5/plexus-container-default-1.5.5.pom"
+    },
+    "org.codehaus.plexus:plexus-containers:pom:1.0.3": {
+      "layout": "org/codehaus/plexus/plexus-containers/1.0.3/plexus-containers-1.0.3.pom",
+      "sha256": "7c75075badcb014443ee94c8c4cad2f4a9905be3ce9430fe7b220afc7fa3a80f",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.0.3/plexus-containers-1.0.3.pom"
+    },
+    "org.codehaus.plexus:plexus-containers:pom:1.5.5": {
+      "layout": "org/codehaus/plexus/plexus-containers/1.5.5/plexus-containers-1.5.5.pom",
+      "sha256": "1bc264824ec876b0ca6f4f5838175c541c638cbc43326a268b9aee7d4778b5ef",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.5.5/plexus-containers-1.5.5.pom"
+    },
+    "org.codehaus.plexus:plexus-interactivity-api:jar:1.0-alpha-4": {
+      "layout": "org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.jar",
+      "sha256": "4f60eb379f93d8b616bc3b4d299f466bc54fcced959f7ad082dae78b89d6a3f0",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.jar"
+    },
+    "org.codehaus.plexus:plexus-interactivity-api:pom:1.0-alpha-4": {
+      "layout": "org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.pom",
+      "sha256": "42aada809ec125bbfe4d38f9d196bbeb59f298b389df96e610269e369b8eb2c9",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.pom"
+    },
+    "org.codehaus.plexus:plexus-interpolation:jar:1.13": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.13/plexus-interpolation-1.13.jar",
+      "sha256": "8e149132ff32907f39560398e222f1733ae959cedd099b32ee31c7b9d3bc1d6f",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.13/plexus-interpolation-1.13.jar"
+    },
+    "org.codehaus.plexus:plexus-interpolation:jar:1.15": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.15/plexus-interpolation-1.15.jar",
+      "sha256": "7111a4eb5f137781b68127a5a02d0208c28f26d2626fbd7a81d1172cd56449a8",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.15/plexus-interpolation-1.15.jar"
+    },
+    "org.codehaus.plexus:plexus-interpolation:pom:1.11": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.11/plexus-interpolation-1.11.pom",
+      "sha256": "b84d281f59b9da528139e0752a0e1cab0bd98d52c58442b00e45c9748e1d9eee",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.11/plexus-interpolation-1.11.pom"
+    },
+    "org.codehaus.plexus:plexus-interpolation:pom:1.12": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.12/plexus-interpolation-1.12.pom",
+      "sha256": "9e1d13d08550026de20cf8120b7e62e0ee842fc9df94140974c082b067fa5b72",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.12/plexus-interpolation-1.12.pom"
+    },
+    "org.codehaus.plexus:plexus-interpolation:pom:1.13": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.13/plexus-interpolation-1.13.pom",
+      "sha256": "e37731ea5ed19d276f33b77c93399fb5df026e1191133b15fbeab73342c6363b",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.13/plexus-interpolation-1.13.pom"
+    },
+    "org.codehaus.plexus:plexus-interpolation:pom:1.15": {
+      "layout": "org/codehaus/plexus/plexus-interpolation/1.15/plexus-interpolation-1.15.pom",
+      "sha256": "4a9f28e95f82a80fbd0632e6305b3c676f4d5e946f93028226d5365f53492bc7",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interpolation/1.15/plexus-interpolation-1.15.pom"
+    },
+    "org.codehaus.plexus:plexus-io:jar:2.0.2": {
+      "layout": "org/codehaus/plexus/plexus-io/2.0.2/plexus-io-2.0.2.jar",
+      "sha256": "e2f88c8813463aabfb1b689f0be551c24c58e8e5508fd5a44f8d20a327b1517f",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/2.0.2/plexus-io-2.0.2.jar"
+    },
+    "org.codehaus.plexus:plexus-io:pom:2.0.2": {
+      "layout": "org/codehaus/plexus/plexus-io/2.0.2/plexus-io-2.0.2.pom",
+      "sha256": "67a1ce072ad9ff4ce37985a1c32827eaeda4660cabe7f69eff2ca1ebff2d23bd",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-io/2.0.2/plexus-io-2.0.2.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:jar:1.5.1": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1.jar",
+      "sha256": "72582f8ba285601fa753ceeda73ff3cbd94c6e78f52ec611621eaa0186165452",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1.jar"
+    },
+    "org.codehaus.plexus:plexus-utils:jar:2.0.5": {
+      "layout": "org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.jar",
+      "sha256": "b4c51a337078b934ad656ee78a2d3a805a507129dc034692c67db0f94b659d3e",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.jar"
+    },
+    "org.codehaus.plexus:plexus-utils:jar:3.0": {
+      "layout": "org/codehaus/plexus/plexus-utils/3.0/plexus-utils-3.0.jar",
+      "sha256": "e67fc0b78b5cbabe6748677ebec9844db5014ac397ab1537558bcd614b5c41e1",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0/plexus-utils-3.0.jar"
+    },
+    "org.codehaus.plexus:plexus-utils:jar:3.0.8": {
+      "layout": "org/codehaus/plexus/plexus-utils/3.0.8/plexus-utils-3.0.8.jar",
+      "sha256": "6c040032841fe6b23612c7a4b52347a4a115fdde748086c399a154b4b108e56b",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0.8/plexus-utils-3.0.8.jar"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.0.4": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.0.4/plexus-utils-1.0.4.pom",
+      "sha256": "36623a9539061d87f078af61ca62c3eacf422eb374641cf8903cdeb759671eb3",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.0.4/plexus-utils-1.0.4.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.4.1": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.4.1/plexus-utils-1.4.1.pom",
+      "sha256": "894261f5b21a2a18519537086181426450300385518e53d2555f5b4a6c1260e7",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.4.1/plexus-utils-1.4.1.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.4.5": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.4.5/plexus-utils-1.4.5.pom",
+      "sha256": "687d05a9521ecb8e319e6beb46abcf53e0e61be647f1c7642a86e22f46814336",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.4.5/plexus-utils-1.4.5.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.5.1": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1.pom",
+      "sha256": "e237bba8d1c65c171b5fe8774a2ff817525df6315b929a2085cf70cff15b1b58",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.5.15": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.5.15/plexus-utils-1.5.15.pom",
+      "sha256": "12a3c9a32b82fdc95223cab1f9d344e14ef3e396da14c4d0013451646f3280e7",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.15/plexus-utils-1.5.15.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.5.5": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.5.5/plexus-utils-1.5.5.pom",
+      "sha256": "f860675cad10e561bfa175d5717e2d8617d40c62321086ca4a85c006a0fa30d1",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.5/plexus-utils-1.5.5.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:1.5.8": {
+      "layout": "org/codehaus/plexus/plexus-utils/1.5.8/plexus-utils-1.5.8.pom",
+      "sha256": "1ff4fb95c218af4a46f71d625212c70f377ccf97ad2e26cb8d4c10709265bf62",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.8/plexus-utils-1.5.8.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:2.0.5": {
+      "layout": "org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.pom",
+      "sha256": "35bc7d1213616236571072b2c56da18f7a57658de8b4a4100645b7054a2b273b",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/2.0.5/plexus-utils-2.0.5.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:3.0": {
+      "layout": "org/codehaus/plexus/plexus-utils/3.0/plexus-utils-3.0.pom",
+      "sha256": "f479d0dc224974b50cfefae14344a4cd8b692b8dbf58df2d8c5c2f13db01d642",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0/plexus-utils-3.0.pom"
+    },
+    "org.codehaus.plexus:plexus-utils:pom:3.0.8": {
+      "layout": "org/codehaus/plexus/plexus-utils/3.0.8/plexus-utils-3.0.8.pom",
+      "sha256": "0f0794dc7bdd60775d1b1e9bf70c55f2e4051bcd3d5e263a56c678080db3bbc1",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0.8/plexus-utils-3.0.8.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:1.0.11": {
+      "layout": "org/codehaus/plexus/plexus/1.0.11/plexus-1.0.11.pom",
+      "sha256": "5197630dcd2336f5b4ab8e6d26e5b8675f5ebd83bd8c91d6aba431b09627d626",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.11/plexus-1.0.11.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:1.0.4": {
+      "layout": "org/codehaus/plexus/plexus/1.0.4/plexus-1.0.4.pom",
+      "sha256": "2242fd02d12b1ca73267fb3d89863025517200e7a4ee426cba4667d0172c74c3",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.4/plexus-1.0.4.pom"
     },
     "org.codehaus.plexus:plexus:pom:2.0.2": {
       "layout": "org/codehaus/plexus/plexus/2.0.2/plexus-2.0.2.pom",
@@ -730,465 +1085,110 @@
       "sha256": "fcc5670db8864c50c16bd96972f0da876f6651a8edc99850e68b2d569c5a4776",
       "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/2.0.3/plexus-2.0.3.pom"
     },
-    "org.codehaus.plexus:plexus-component-annotations:jar:1.5.5": {
-      "layout": "org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar",
-      "sha256": "4df7a6a7be64b35bbccf60b5c115697f9ea3421d22674ae67135dde375fcca1f",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-component-annotations/1.5.5/plexus-component-annotations-1.5.5.jar"
-    },
-    "org.apache.maven.plugins:maven-resources-plugin:jar:2.6": {
-      "layout": "org/apache/maven/plugins/maven-resources-plugin/2.6/maven-resources-plugin-2.6.jar",
-      "sha256": "07bd1b98b5b029af91fabcf99a9b3463b9dc09b993f28c2ee0ccc98265888ca6",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/2.6/maven-resources-plugin-2.6.jar"
-    },
-    "commons-lang:commons-lang:pom:2.1": {
-      "layout": "commons-lang/commons-lang/2.1/commons-lang-2.1.pom",
-      "sha256": "f1a709cd489f23498a0b6b3dfbfc0d21d4f15904791446dec7f8a58a7da5bd6a",
-      "url": "https://repo.maven.apache.org/maven2/commons-lang/commons-lang/2.1/commons-lang-2.1.pom"
-    },
-    "org.apache.maven.surefire:maven-surefire-common:pom:2.12.4": {
-      "layout": "org/apache/maven/surefire/maven-surefire-common/2.12.4/maven-surefire-common-2.12.4.pom",
-      "sha256": "14df735a04e945f31198b4e9cbfddd103d238108d4f35bf77441216f0c4a4b29",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/surefire/maven-surefire-common/2.12.4/maven-surefire-common-2.12.4.pom"
-    },
-    "org.apache.maven:maven-plugin-api:pom:2.2.1": {
-      "layout": "org/apache/maven/maven-plugin-api/2.2.1/maven-plugin-api-2.2.1.pom",
-      "sha256": "c10d0460c2d5c5076304598965991d6257d1bf31bdef921a17ce3d059bce654e",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.2.1/maven-plugin-api-2.2.1.pom"
-    },
-    "org.codehaus.plexus:plexus-classworlds:pom:2.2.2": {
-      "layout": "org/codehaus/plexus/plexus-classworlds/2.2.2/plexus-classworlds-2.2.2.pom",
-      "sha256": "6aad43eb7fee989d50f1ecaf4a8030c708f9c9ea3eb72ee023d76746ff89570a",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.2.2/plexus-classworlds-2.2.2.pom"
-    },
-    "com.google:google:pom:1": {
-      "layout": "com/google/google/1/google-1.pom",
-      "sha256": "cd6db17a11a31ede794ccbd1df0e4d9750f640234731f21cff885a9997277e81",
-      "url": "https://repo.maven.apache.org/maven2/com/google/google/1/google-1.pom"
-    },
-    "org.apache.maven:maven-plugin-parameter-documenter:pom:2.2.1": {
-      "layout": "org/apache/maven/maven-plugin-parameter-documenter/2.2.1/maven-plugin-parameter-documenter-2.2.1.pom",
-      "sha256": "902b0160f7b81ec76452468f8ae087fc1cfefc08367c84d9197512dfb01d845d",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.2.1/maven-plugin-parameter-documenter-2.2.1.pom"
-    },
-    "org.apache.xbean:xbean:pom:3.4": {
-      "layout": "org/apache/xbean/xbean/3.4/xbean-3.4.pom",
-      "sha256": "56ab9c6c2d022a9b7079006ba500a996cd2c21411d53cac524933af20c5a4b99",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/xbean/xbean/3.4/xbean-3.4.pom"
-    },
-    "org.sonatype.plexus:plexus-build-api:pom:0.0.4": {
-      "layout": "org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.pom",
-      "sha256": "9bd824511766b9f512d7badbf24add39ece050c75e07d6cacc954517f49ea465",
-      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.pom"
-    },
-    "org.apache.maven.shared:maven-common-artifact-filters:pom:1.3": {
-      "layout": "org/apache/maven/shared/maven-common-artifact-filters/1.3/maven-common-artifact-filters-1.3.pom",
-      "sha256": "7587bc31ee5285debdb0b87b3446ccece28c2716820232adc0089295e84c265d",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-common-artifact-filters/1.3/maven-common-artifact-filters-1.3.pom"
-    },
-    "org.codehaus.plexus:plexus-container-default:pom:1.0-alpha-9": {
-      "layout": "org/codehaus/plexus/plexus-container-default/1.0-alpha-9/plexus-container-default-1.0-alpha-9.pom",
-      "sha256": "8864b08e353614d0c4111f455f8b3907179f8b0be6c0845bc7f31ef6daf206ec",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-9/plexus-container-default-1.0-alpha-9.pom"
-    },
-    "com.google.collections:google-collections:pom:1.0": {
-      "layout": "com/google/collections/google-collections/1.0/google-collections-1.0.pom",
-      "sha256": "893d56afcea1b22f83220fd7e49a6668c5b8901e39bd59dc57b42f55673721ce",
-      "url": "https://repo.maven.apache.org/maven2/com/google/collections/google-collections/1.0/google-collections-1.0.pom"
-    },
-    "org.apache.maven.plugins:maven-resources-plugin:pom:2.6": {
-      "layout": "org/apache/maven/plugins/maven-resources-plugin/2.6/maven-resources-plugin-2.6.pom",
-      "sha256": "a7842d002fbc7d2a84217106be909bc85ea35aa47031e410ab8afbb3b3364e2d",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-resources-plugin/2.6/maven-resources-plugin-2.6.pom"
-    },
-    "org.slf4j:jcl-over-slf4j:pom:1.5.6": {
-      "layout": "org/slf4j/jcl-over-slf4j/1.5.6/jcl-over-slf4j-1.5.6.pom",
-      "sha256": "d71d7748e68bb9cb7ad38b95d17c0466e31fc1f4d15bb1e635f3ebad34a38ff3",
-      "url": "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.5.6/jcl-over-slf4j-1.5.6.pom"
-    },
-    "org.apache.maven.plugins:maven-surefire-plugin:jar:2.12.4": {
-      "layout": "org/apache/maven/plugins/maven-surefire-plugin/2.12.4/maven-surefire-plugin-2.12.4.jar",
-      "sha256": "da14e7c9643cd3991355730455324a46ac83d633da6446cde96ef8356afa42f4",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/2.12.4/maven-surefire-plugin-2.12.4.jar"
-    },
-    "org.codehaus.plexus:plexus:pom:1.0.11": {
-      "layout": "org/codehaus/plexus/plexus/1.0.11/plexus-1.0.11.pom",
-      "sha256": "5197630dcd2336f5b4ab8e6d26e5b8675f5ebd83bd8c91d6aba431b09627d626",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.11/plexus-1.0.11.pom"
-    },
-    "org.apache.maven.reporting:maven-reporting-api:jar:2.0.9": {
-      "layout": "org/apache/maven/reporting/maven-reporting-api/2.0.9/maven-reporting-api-2.0.9.jar",
-      "sha256": "b43cd126a7dde90857cb9ad6a46ce65787a6597fec729b509a074e6d087e893a",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.0.9/maven-reporting-api-2.0.9.jar"
-    },
-    "org.apache.maven:maven-model:pom:2.0.6": {
-      "layout": "org/apache/maven/maven-model/2.0.6/maven-model-2.0.6.pom",
-      "sha256": "e88566fd64906e8e9a2315e5cb67efb7e0f4947a1c45a45cff399f64a235ac1f",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.6/maven-model-2.0.6.pom"
-    },
-    "org.apache.maven:maven-model:pom:2.0.9": {
-      "layout": "org/apache/maven/maven-model/2.0.9/maven-model-2.0.9.pom",
-      "sha256": "2bfc8ce93b46c1bbe8e809197a2f970c5573d2b0d3412c84d7cdfa5961299087",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.0.9/maven-model-2.0.9.pom"
-    },
-    "org.apache.maven:maven-monitor:pom:2.0.6": {
-      "layout": "org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.pom",
-      "sha256": "2cfd187d6465c5ad99552da8441d31ff0c1ced1808d2f624dbdb49223d3baa89",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.pom"
-    },
-    "org.apache.maven:maven-plugin-parameter-documenter:jar:2.0.6": {
-      "layout": "org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.jar",
-      "sha256": "b5f0dd177264a6e25ce0ed8724f8b6f3bca48b215b9ff4576e1bec7b0773f9e8",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.jar"
-    },
-    "log4j:log4j:jar:1.2.12": {
-      "layout": "log4j/log4j/1.2.12/log4j-1.2.12.jar",
-      "sha256": "dc67378cf428c06408e7959e83bdc1518dd22ccd313e7c28a986612d65c276c7",
-      "url": "https://repo.maven.apache.org/maven2/log4j/log4j/1.2.12/log4j-1.2.12.jar"
-    },
-    "org.apache.maven:maven-monitor:pom:2.0.9": {
-      "layout": "org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9.pom",
-      "sha256": "4fe978f252f57c1768d917603127db3b82e98820059b4943ae04b79c5ac79419",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9.pom"
-    },
-    "org.apache.maven:maven-plugin-parameter-documenter:jar:2.0.9": {
-      "layout": "org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9.jar",
-      "sha256": "3be9db19335747e8a22f768fab3539992a66d280ccff5f8cd487cada733aee98",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9.jar"
-    },
-    "org.apache.maven.reporting:maven-reporting-api:jar:2.0.6": {
-      "layout": "org/apache/maven/reporting/maven-reporting-api/2.0.6/maven-reporting-api-2.0.6.jar",
-      "sha256": "ba372ac9e52b481671bb3ea913063cd66747780de340d0c3b1f18c49ec998786",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.0.6/maven-reporting-api-2.0.6.jar"
-    },
-    "org.codehaus.plexus:plexus-utils:pom:1.5.8": {
-      "layout": "org/codehaus/plexus/plexus-utils/1.5.8/plexus-utils-1.5.8.pom",
-      "sha256": "1ff4fb95c218af4a46f71d625212c70f377ccf97ad2e26cb8d4c10709265bf62",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.8/plexus-utils-1.5.8.pom"
-    },
-    "junit:junit:jar:3.8.2": {
-      "layout": "junit/junit/3.8.2/junit-3.8.2.jar",
-      "sha256": "ecdcc08183708ea3f7b0ddc96f19678a0db8af1fb397791d484aed63200558b0",
-      "url": "https://repo.maven.apache.org/maven2/junit/junit/3.8.2/junit-3.8.2.jar"
-    },
-    "org.apache.maven:maven-artifact-manager:pom:2.2.1": {
-      "layout": "org/apache/maven/maven-artifact-manager/2.2.1/maven-artifact-manager-2.2.1.pom",
-      "sha256": "ecf58351f8fe0c398b8b452216705bece5291b9b327d30202c16b28ac680450c",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact-manager/2.2.1/maven-artifact-manager-2.2.1.pom"
-    },
-    "junit:junit:jar:3.8.1": {
-      "layout": "junit/junit/3.8.1/junit-3.8.1.jar",
-      "sha256": "b58e459509e190bed737f3592bc1950485322846cf10e78ded1d065153012d70",
-      "url": "https://repo.maven.apache.org/maven2/junit/junit/3.8.1/junit-3.8.1.jar"
-    },
-    "org.apache.maven:maven-toolchain:pom:1.0": {
-      "layout": "org/apache/maven/maven-toolchain/1.0/maven-toolchain-1.0.pom",
-      "sha256": "665a0be425b12cc6938a41f7ebde2c4c7c23b02b3826344462001057449d503d",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/1.0/maven-toolchain-1.0.pom"
-    },
-    "org.codehaus.plexus:plexus-utils:pom:1.5.1": {
-      "layout": "org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1.pom",
-      "sha256": "e237bba8d1c65c171b5fe8774a2ff817525df6315b929a2085cf70cff15b1b58",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1.pom"
-    },
-    "org.apache.maven:maven-settings:jar:2.0.9": {
-      "layout": "org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9.jar",
-      "sha256": "1e5c98ebc4b9ae1f2c8d843c1dd9701a1c25b9afaff143c3e1fa4d90c22850fe",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0.9/maven-settings-2.0.9.jar"
-    },
-    "org.codehaus.plexus:plexus-utils:pom:1.5.5": {
-      "layout": "org/codehaus/plexus/plexus-utils/1.5.5/plexus-utils-1.5.5.pom",
-      "sha256": "f860675cad10e561bfa175d5717e2d8617d40c62321086ca4a85c006a0fa30d1",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.5.5/plexus-utils-1.5.5.pom"
-    },
-    "org.apache.maven:maven-settings:jar:2.0.6": {
-      "layout": "org/apache/maven/maven-settings/2.0.6/maven-settings-2.0.6.jar",
-      "sha256": "bb7af11f28a37d21bf20e11705c78aa4adce3aaff1b9b981c031c6be1aa0ec97",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-settings/2.0.6/maven-settings-2.0.6.jar"
-    },
-    "org.apache.maven.shared:maven-shared-components:pom:12": {
-      "layout": "org/apache/maven/shared/maven-shared-components/12/maven-shared-components-12.pom",
-      "sha256": "231a3c87248f98eed75cc32512adb5837b8141e52ba94af0fdb3e10292e1766e",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/12/maven-shared-components-12.pom"
-    },
-    "commons-cli:commons-cli:jar:1.0": {
-      "layout": "commons-cli/commons-cli/1.0/commons-cli-1.0.jar",
-      "sha256": "43f24850b7b7b7d79c5fa652418518fbdf427e602b1edabe6f11b85fb93eb013",
-      "url": "https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.0/commons-cli-1.0.jar"
-    },
-    "org.apache.maven.shared:maven-shared-components:pom:18": {
-      "layout": "org/apache/maven/shared/maven-shared-components/18/maven-shared-components-18.pom",
-      "sha256": "a1d54fb81b5a8f197f5b3d0a928f63da2278c79bc8dd06e0be93593403f05775",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/18/maven-shared-components-18.pom"
-    },
-    "org.apache.maven.shared:maven-shared-components:pom:17": {
-      "layout": "org/apache/maven/shared/maven-shared-components/17/maven-shared-components-17.pom",
-      "sha256": "4b96931a6d12491f858b44b2dbea50c1070c960232c041b966189dc905ac2631",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/17/maven-shared-components-17.pom"
-    },
-    "org.codehaus.plexus:plexus-compiler-javac:pom:2.2": {
-      "layout": "org/codehaus/plexus/plexus-compiler-javac/2.2/plexus-compiler-javac-2.2.pom",
-      "sha256": "18a41342ece8d3016b4b5ec3e84b52331420413a17ce298574c1f61e26733955",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-javac/2.2/plexus-compiler-javac-2.2.pom"
-    },
-    "org.apache.maven.shared:maven-shared-components:pom:19": {
-      "layout": "org/apache/maven/shared/maven-shared-components/19/maven-shared-components-19.pom",
-      "sha256": "d82408269aada2eb1521ee8ff17f7c67333684f8ed2a09a9e35badd2e7575957",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/19/maven-shared-components-19.pom"
-    },
-    "org.apache.maven.shared:maven-shared-incremental:pom:1.1": {
-      "layout": "org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.pom",
-      "sha256": "f21d19eb49b4a66cd85354a9ee7335439ea92a368173760a202766008cc19924",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-incremental/1.1/maven-shared-incremental-1.1.pom"
-    },
-    "org.codehaus.plexus:plexus-interactivity-api:jar:1.0-alpha-4": {
-      "layout": "org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.jar",
-      "sha256": "4f60eb379f93d8b616bc3b4d299f466bc54fcced959f7ad082dae78b89d6a3f0",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-interactivity-api/1.0-alpha-4/plexus-interactivity-api-1.0-alpha-4.jar"
-    },
-    "org.apache.maven:maven-project:pom:2.2.1": {
-      "layout": "org/apache/maven/maven-project/2.2.1/maven-project-2.2.1.pom",
-      "sha256": "34af0baedaef19375b7c1a7da967e9089d5e0754647fdbe9a302590392874b77",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-project/2.2.1/maven-project-2.2.1.pom"
-    },
-    "org.apache.maven.doxia:doxia:pom:1.0-alpha-7": {
-      "layout": "org/apache/maven/doxia/doxia/1.0-alpha-7/doxia-1.0-alpha-7.pom",
-      "sha256": "172106a7ac51408883a074a1b847768e71c40fbbd969c8d645d2570026b811be",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/doxia/doxia/1.0-alpha-7/doxia-1.0-alpha-7.pom"
-    },
-    "org.codehaus.plexus:plexus-utils:pom:3.0.8": {
-      "layout": "org/codehaus/plexus/plexus-utils/3.0.8/plexus-utils-3.0.8.pom",
-      "sha256": "0f0794dc7bdd60775d1b1e9bf70c55f2e4051bcd3d5e263a56c678080db3bbc1",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0.8/plexus-utils-3.0.8.pom"
-    },
-    "org.codehaus.plexus:plexus-compilers:pom:2.2": {
-      "layout": "org/codehaus/plexus/plexus-compilers/2.2/plexus-compilers-2.2.pom",
-      "sha256": "f6c8d1ee6e02ecd7376346b3f526e90b9e2c4d6128efa3b33cd463bcef8d480a",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compilers/2.2/plexus-compilers-2.2.pom"
-    },
-    "com.google.code.findbugs:jsr305:pom:2.0.1": {
-      "layout": "com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.pom",
-      "sha256": "02c12c3c2ae12dd475219ff691c82a4d9ea21f44bc594a181295bf6d43dcfbb0",
-      "url": "https://repo.maven.apache.org/maven2/com/google/code/findbugs/jsr305/2.0.1/jsr305-2.0.1.pom"
-    },
-    "org.codehaus.plexus:plexus:pom:1.0.4": {
-      "layout": "org/codehaus/plexus/plexus/1.0.4/plexus-1.0.4.pom",
-      "sha256": "2242fd02d12b1ca73267fb3d89863025517200e7a4ee426cba4667d0172c74c3",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/1.0.4/plexus-1.0.4.pom"
-    },
-    "org.apache.maven:maven-repository-metadata:jar:2.0.6": {
-      "layout": "org/apache/maven/maven-repository-metadata/2.0.6/maven-repository-metadata-2.0.6.jar",
-      "sha256": "dce817d7c4229d5e666247c05853ef8ad7ac1b72d27953501c4a1ea739f67b25",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.6/maven-repository-metadata-2.0.6.jar"
-    },
-    "org.apache.commons:commons-lang3:jar:3.1": {
-      "layout": "org/apache/commons/commons-lang3/3.1/commons-lang3-3.1.jar",
-      "sha256": "131f0519a8e4602e47cf024bfd7e0834bcf5592a7207f9a2fdb711d4f5afc166",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.1/commons-lang3-3.1.jar"
-    },
-    "org.codehaus.plexus:plexus-containers:pom:1.5.5": {
-      "layout": "org/codehaus/plexus/plexus-containers/1.5.5/plexus-containers-1.5.5.pom",
-      "sha256": "1bc264824ec876b0ca6f4f5838175c541c638cbc43326a268b9aee7d4778b5ef",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-containers/1.5.5/plexus-containers-1.5.5.pom"
-    },
-    "org.apache.maven:maven:pom:2.2.1": {
-      "layout": "org/apache/maven/maven/2.2.1/maven-2.2.1.pom",
-      "sha256": "d135cff96dcbbc8a5fab30180e557cae620373cf26941d4c738a88896a2d98ed",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/2.2.1/maven-2.2.1.pom"
-    },
-    "org.apache.maven.plugin-tools:maven-plugin-tools:pom:3.1": {
-      "layout": "org/apache/maven/plugin-tools/maven-plugin-tools/3.1/maven-plugin-tools-3.1.pom",
-      "sha256": "ea3422417c914115799d62be376bcf8f79f05b896905f84e9da55af5af66abec",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugin-tools/maven-plugin-tools/3.1/maven-plugin-tools-3.1.pom"
-    },
-    "org.apache.maven:maven-repository-metadata:jar:2.0.9": {
-      "layout": "org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9.jar",
-      "sha256": "2c302f060de887716be438e0eb0c3d89d7ece213631882446ee0b19880c00dbd",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-repository-metadata/2.0.9/maven-repository-metadata-2.0.9.jar"
-    },
-    "org.codehaus.plexus:plexus-utils:jar:3.0": {
-      "layout": "org/codehaus/plexus/plexus-utils/3.0/plexus-utils-3.0.jar",
-      "sha256": "e67fc0b78b5cbabe6748677ebec9844db5014ac397ab1537558bcd614b5c41e1",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0/plexus-utils-3.0.jar"
-    },
-    "org.apache.maven:maven-plugin-api:jar:2.0.9": {
-      "layout": "org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9.jar",
-      "sha256": "f1e4b0af3079cc0db361eab9429a3cda7b118cd032211c7e61b3805a62bfde1f",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.9/maven-plugin-api-2.0.9.jar"
-    },
-    "org.codehaus.plexus:plexus-utils:pom:1.4.1": {
-      "layout": "org/codehaus/plexus/plexus-utils/1.4.1/plexus-utils-1.4.1.pom",
-      "sha256": "894261f5b21a2a18519537086181426450300385518e53d2555f5b4a6c1260e7",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.4.1/plexus-utils-1.4.1.pom"
-    },
-    "org.codehaus.plexus:plexus-classworlds:jar:2.2.2": {
-      "layout": "org/codehaus/plexus/plexus-classworlds/2.2.2/plexus-classworlds-2.2.2.jar",
-      "sha256": "13a90763640e445ffa432ce9586e416572645c3ed4db6a860fe0d28256ad40ce",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-classworlds/2.2.2/plexus-classworlds-2.2.2.jar"
-    },
-    "commons-cli:commons-cli:pom:1.0": {
-      "layout": "commons-cli/commons-cli/1.0/commons-cli-1.0.pom",
-      "sha256": "97ee40f4e80ca5ecc20162f4e97ee1adfeac1b45ba88b923d5a521e487c9c407",
-      "url": "https://repo.maven.apache.org/maven2/commons-cli/commons-cli/1.0/commons-cli-1.0.pom"
-    },
-    "org.apache.maven:maven-plugin-api:jar:2.0.6": {
-      "layout": "org/apache/maven/maven-plugin-api/2.0.6/maven-plugin-api-2.0.6.jar",
-      "sha256": "a1b54bbe38d25ccd3179c5563156b3b0c0ecd014647c3ebaeba8e92b2e2e5053",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-api/2.0.6/maven-plugin-api-2.0.6.jar"
-    },
-    "org.codehaus.plexus:plexus-utils:pom:1.4.5": {
-      "layout": "org/codehaus/plexus/plexus-utils/1.4.5/plexus-utils-1.4.5.pom",
-      "sha256": "687d05a9521ecb8e319e6beb46abcf53e0e61be647f1c7642a86e22f46814336",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.4.5/plexus-utils-1.4.5.pom"
-    },
-    "org.apache.maven:maven-core:pom:2.2.1": {
-      "layout": "org/apache/maven/maven-core/2.2.1/maven-core-2.2.1.pom",
-      "sha256": "5cc81603cab47bf20dbfd5e28e311da1fd26f2e3617b50547da5cd0b4f59edf3",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-core/2.2.1/maven-core-2.2.1.pom"
-    },
-    "org.apache.maven:maven-plugin-parameter-documenter:pom:2.0.6": {
-      "layout": "org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.pom",
-      "sha256": "b5b53025b13fa0013ae2caede21f9af4215c25279db4ee0a1f943aaa8815c174",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.6/maven-plugin-parameter-documenter-2.0.6.pom"
-    },
-    "org.codehaus.plexus:plexus-container-default:jar:1.0-alpha-9-stable-1": {
-      "layout": "org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.jar",
-      "sha256": "7c758612888782ccfe376823aee7cdcc7e0cdafb097f7ef50295a0b0c3a16edf",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.jar"
-    },
-    "org.apache.maven:maven-monitor:jar:2.0.6": {
-      "layout": "org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.jar",
-      "sha256": "47289bc307849383d41eddbe3800f1945b2204ab319b0d38e391f6780c37b4e3",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.6/maven-monitor-2.0.6.jar"
-    },
-    "org.apache.maven.reporting:maven-reporting-api:pom:2.0.9": {
-      "layout": "org/apache/maven/reporting/maven-reporting-api/2.0.9/maven-reporting-api-2.0.9.pom",
-      "sha256": "e50e96c88041e2236420e5483b407175c07f401b0d49f0744fa48de2d372448d",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.0.9/maven-reporting-api-2.0.9.pom"
-    },
-    "org.apache.maven:maven-toolchain:jar:1.0": {
-      "layout": "org/apache/maven/maven-toolchain/1.0/maven-toolchain-1.0.jar",
-      "sha256": "95730d85b872517036b12ef7d474e72f2467f09ae40006169570450e6de6ac95",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/1.0/maven-toolchain-1.0.jar"
-    },
-    "org.apache.maven.plugins:maven-plugins:pom:24": {
-      "layout": "org/apache/maven/plugins/maven-plugins/24/maven-plugins-24.pom",
-      "sha256": "bfba38bd72d1a898f6f88e17cea240c67426be64d00c166b29c461d9bc149e56",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/24/maven-plugins-24.pom"
-    },
-    "org.apache.maven.plugins:maven-plugins:pom:23": {
-      "layout": "org/apache/maven/plugins/maven-plugins/23/maven-plugins-23.pom",
-      "sha256": "e07710c7d516a873c8fcafe85840d8a1a78f460c9a364d1c57b1d9e4554639ce",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/23/maven-plugins-23.pom"
-    },
-    "org.apache.maven.plugins:maven-plugins:pom:22": {
-      "layout": "org/apache/maven/plugins/maven-plugins/22/maven-plugins-22.pom",
-      "sha256": "34d303bbdd31d34f5a1570549b0e134b72afb18db53d8fcfdad222d51e941630",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/22/maven-plugins-22.pom"
-    },
-    "org.apache.maven:maven-toolchain:pom:2.0.9": {
-      "layout": "org/apache/maven/maven-toolchain/2.0.9/maven-toolchain-2.0.9.pom",
-      "sha256": "7fca590bc5f4b4841c3a00dade5fb9e1f454f178e45e5e4165304e7ce1be35dc",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-toolchain/2.0.9/maven-toolchain-2.0.9.pom"
-    },
-    "org.apache.maven:maven-monitor:jar:2.0.9": {
-      "layout": "org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9.jar",
-      "sha256": "69f5fbf13f7e54885b53b5c2c00adb24178e43a6e997c6350a45a7dc287ebd2f",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-monitor/2.0.9/maven-monitor-2.0.9.jar"
-    },
-    "org.apache.maven:maven-plugin-parameter-documenter:pom:2.0.9": {
-      "layout": "org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9.pom",
-      "sha256": "3d356e97c1ab8c5673e8908b07e1e50d842dab8cbea8a2082f87016b891f91a6",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-parameter-documenter/2.0.9/maven-plugin-parameter-documenter-2.0.9.pom"
+    "org.codehaus.plexus:plexus:pom:2.0.6": {
+      "layout": "org/codehaus/plexus/plexus/2.0.6/plexus-2.0.6.pom",
+      "sha256": "bea12e747708d25e73410ca1c731ebdfa102e8bdb6ec7d81bd4522583b234bcc",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/2.0.6/plexus-2.0.6.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:2.0.7": {
+      "layout": "org/codehaus/plexus/plexus/2.0.7/plexus-2.0.7.pom",
+      "sha256": "2b59062030ab0a15c5d0977ba22421706368926488739a65f25793e715cc8a74",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/2.0.7/plexus-2.0.7.pom"
+    },
+    "org.codehaus.plexus:plexus:pom:3.0.1": {
+      "layout": "org/codehaus/plexus/plexus/3.0.1/plexus-3.0.1.pom",
+      "sha256": "1649f67caab553dd7e6b98002dcc670dab3f624c78f1259c8323e705b0c41e32",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/3.0.1/plexus-3.0.1.pom"
     },
     "org.codehaus.plexus:plexus:pom:3.2": {
       "layout": "org/codehaus/plexus/plexus/3.2/plexus-3.2.pom",
       "sha256": "1c7c732fdc37e7705af76835b1589fedd9db2abe1baa76b16bd061bd7291de4f",
       "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/3.2/plexus-3.2.pom"
     },
-    "org.apache.maven.reporting:maven-reporting-api:pom:2.0.6": {
-      "layout": "org/apache/maven/reporting/maven-reporting-api/2.0.6/maven-reporting-api-2.0.6.pom",
-      "sha256": "4ac659858bac5929ea8fc183d7ce4b588d7e69363a76277f6a26349393686657",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/reporting/maven-reporting-api/2.0.6/maven-reporting-api-2.0.6.pom"
+    "org.codehaus.plexus:plexus:pom:3.3.1": {
+      "layout": "org/codehaus/plexus/plexus/3.3.1/plexus-3.3.1.pom",
+      "sha256": "6ec96f889bc29250f90b167c14e547f1b05aa23565c63f9079595befbde816bb",
+      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/3.3.1/plexus-3.3.1.pom"
     },
-    "org.apache.maven:maven-plugin-descriptor:jar:2.0.9": {
-      "layout": "org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9.jar",
-      "sha256": "d4b0d72958125b6cedc12c7ed5c50a20624e1e57ee37d622fb67f30dcf0327b3",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.9/maven-plugin-descriptor-2.0.9.jar"
+    "org.slf4j:jcl-over-slf4j:pom:1.5.6": {
+      "layout": "org/slf4j/jcl-over-slf4j/1.5.6/jcl-over-slf4j-1.5.6.pom",
+      "sha256": "d71d7748e68bb9cb7ad38b95d17c0466e31fc1f4d15bb1e635f3ebad34a38ff3",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/jcl-over-slf4j/1.5.6/jcl-over-slf4j-1.5.6.pom"
     },
-    "org.apache.maven:maven-artifact:pom:2.0.9": {
-      "layout": "org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9.pom",
-      "sha256": "77f614225a71c207a45f270be0190d34bac4dbc14684cda26015717710411aee",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.9/maven-artifact-2.0.9.pom"
+    "org.slf4j:slf4j-api:pom:1.5.6": {
+      "layout": "org/slf4j/slf4j-api/1.5.6/slf4j-api-1.5.6.pom",
+      "sha256": "91b0a0d016b8c0cba1ddd8a5c59e5bf5c2a9b49b95577e8e38927a7fdff55ce8",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.5.6/slf4j-api-1.5.6.pom"
     },
-    "org.codehaus.plexus:plexus-container-default:pom:1.0-alpha-9-stable-1": {
-      "layout": "org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.pom",
-      "sha256": "ef71d45a49edfe76be0f520312a76bc2aae73ec0743a5ffffe10d30122c6e2b2",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-container-default/1.0-alpha-9-stable-1/plexus-container-default-1.0-alpha-9-stable-1.pom"
-    },
-    "org.apache.maven:maven-plugin-descriptor:jar:2.0.6": {
-      "layout": "org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.jar",
-      "sha256": "e6e99e03921e576358e24a797e3034d0587ad08dac8ebf78b3fcf3e1a96a37d9",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-plugin-descriptor/2.0.6/maven-plugin-descriptor-2.0.6.jar"
-    },
-    "org.codehaus.plexus:plexus-utils:pom:3.0": {
-      "layout": "org/codehaus/plexus/plexus-utils/3.0/plexus-utils-3.0.pom",
-      "sha256": "f479d0dc224974b50cfefae14344a4cd8b692b8dbf58df2d8c5c2f13db01d642",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/3.0/plexus-utils-3.0.pom"
-    },
-    "org.codehaus.plexus:plexus-compiler-javac:jar:2.2": {
-      "layout": "org/codehaus/plexus/plexus-compiler-javac/2.2/plexus-compiler-javac-2.2.jar",
-      "sha256": "03344d155153620b4de75d322d1b422701ac827dd0c631def1c7f46abf81386d",
-      "url": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-compiler-javac/2.2/plexus-compiler-javac-2.2.jar"
+    "org.slf4j:slf4j-jdk14:pom:1.5.6": {
+      "layout": "org/slf4j/slf4j-jdk14/1.5.6/slf4j-jdk14-1.5.6.pom",
+      "sha256": "85f97344eeeed2714eda6f800aa712c1aa7405b0d7f98e207499363f82f37eec",
+      "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-jdk14/1.5.6/slf4j-jdk14-1.5.6.pom"
     },
     "org.slf4j:slf4j-parent:pom:1.5.6": {
       "layout": "org/slf4j/slf4j-parent/1.5.6/slf4j-parent-1.5.6.pom",
       "sha256": "b9d17d6f915b389c7dd77f170d6fcc77f1c7d6c7362fefb146043d8412defddd",
       "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/1.5.6/slf4j-parent-1.5.6.pom"
     },
-    "org.apache.maven.plugins:maven-surefire-plugin:pom:2.12.4": {
-      "layout": "org/apache/maven/plugins/maven-surefire-plugin/2.12.4/maven-surefire-plugin-2.12.4.pom",
-      "sha256": "91e7b0ac3866d8932cf12a5c676223f48b1c4a4c65b9a73e150cae96418abfbc",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/2.12.4/maven-surefire-plugin-2.12.4.pom"
+    "org.sonatype.forge:forge-parent:pom:10": {
+      "layout": "org/sonatype/forge/forge-parent/10/forge-parent-10.pom",
+      "sha256": "c14fb9c32b59cc03251f609416db7c0cff01f811edcccb4f6a865d6e7046bd0b",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/10/forge-parent-10.pom"
     },
-    "log4j:log4j:pom:1.2.12": {
-      "layout": "log4j/log4j/1.2.12/log4j-1.2.12.pom",
-      "sha256": "cb54dedc5d8c4510148dfa792701cbac1a84c383a84f48f5a32e6d7e460bbb72",
-      "url": "https://repo.maven.apache.org/maven2/log4j/log4j/1.2.12/log4j-1.2.12.pom"
+    "org.sonatype.forge:forge-parent:pom:3": {
+      "layout": "org/sonatype/forge/forge-parent/3/forge-parent-3.pom",
+      "sha256": "03263b68791fb11e7464ffcc2c3de7eaeae235de8c94827ce6407e0454d2aae9",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/3/forge-parent-3.pom"
     },
-    "org.apache:apache:pom:6": {
-      "layout": "org/apache/apache/6/apache-6.pom",
-      "sha256": "12edb5096e13f40c362d0bd40902589fa9586505123fa26799ce50b116fa5bb3",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/6/apache-6.pom"
+    "org.sonatype.forge:forge-parent:pom:4": {
+      "layout": "org/sonatype/forge/forge-parent/4/forge-parent-4.pom",
+      "sha256": "1838d132479005b4b7459b798e9d9915515090c288082fdcd86db0b10983a24c",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/4/forge-parent-4.pom"
     },
-    "org.apache.maven:maven-artifact:pom:2.0.6": {
-      "layout": "org/apache/maven/maven-artifact/2.0.6/maven-artifact-2.0.6.pom",
-      "sha256": "7231047667b34a36cfed19d51ef38c9755e97e1acf11595a4b503c5ce7f0c595",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-artifact/2.0.6/maven-artifact-2.0.6.pom"
+    "org.sonatype.forge:forge-parent:pom:5": {
+      "layout": "org/sonatype/forge/forge-parent/5/forge-parent-5.pom",
+      "sha256": "e56188aa8ce51278006aa90bc7e0f304a81e2f1219f462e7d21f262535cd2795",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/forge/forge-parent/5/forge-parent-5.pom"
     },
-    "org.apache.maven:maven-model:pom:2.2.1": {
-      "layout": "org/apache/maven/maven-model/2.2.1/maven-model-2.2.1.pom",
-      "sha256": "62dd8e35a2c4432bb22f8250bbfe08639635599b4064d5d747bd24cf3c02fac5",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/2.2.1/maven-model-2.2.1.pom"
+    "org.sonatype.plexus:plexus-build-api:jar:0.0.4": {
+      "layout": "org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.jar",
+      "sha256": "d2d415ba26078a84e97816fd444361def86dec65a23b4278d95cfb1c285f2649",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.jar"
     },
-    "org.apache:apache:pom:9": {
-      "layout": "org/apache/apache/9/apache-9.pom",
-      "sha256": "4946e60a547c8eda69f3bc23c5b6f0dadcf8469ea49b1d1da7de34aecfcf18dd",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/apache/9/apache-9.pom"
+    "org.sonatype.plexus:plexus-build-api:pom:0.0.4": {
+      "layout": "org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.pom",
+      "sha256": "9bd824511766b9f512d7badbf24add39ece050c75e07d6cacc954517f49ea465",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-build-api/0.0.4/plexus-build-api-0.0.4.pom"
     },
-    "classworlds:classworlds:pom:1.1": {
-      "layout": "classworlds/classworlds/1.1/classworlds-1.1.pom",
-      "sha256": "25a1efc00bcd1f029fd20c44df843b8b12d1fa17485235470764f011d2f5cb29",
-      "url": "https://repo.maven.apache.org/maven2/classworlds/classworlds/1.1/classworlds-1.1.pom"
+    "org.sonatype.plexus:plexus-cipher:pom:1.4": {
+      "layout": "org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.pom",
+      "sha256": "a63a2e23988cca7fac6c93886d6f0506fd26d88d7e8cc0cb89b9c6e0d6c994ad",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-cipher/1.4/plexus-cipher-1.4.pom"
     },
-    "org.apache.commons:commons-lang3:pom:3.1": {
-      "layout": "org/apache/commons/commons-lang3/3.1/commons-lang3-3.1.pom",
-      "sha256": "043ab78d83f630af65c0c0e4289d584d5a816c82533814f3f7fac4b5509fded2",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.1/commons-lang3-3.1.pom"
+    "org.sonatype.plexus:plexus-sec-dispatcher:pom:1.3": {
+      "layout": "org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.pom",
+      "sha256": "d5e650c50ef6958c028ed024b59af04cf3d38e1453a77d542b6b484bc0f4ca0b",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/plexus/plexus-sec-dispatcher/1.3/plexus-sec-dispatcher-1.3.pom"
     },
-    "org.apache.maven.shared:maven-filtering:pom:1.1": {
-      "layout": "org/apache/maven/shared/maven-filtering/1.1/maven-filtering-1.1.pom",
-      "sha256": "9f4bf710d0de3c4dde45182aae3d604784b4e2f91696e27f3411286ef96d181c",
-      "url": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-filtering/1.1/maven-filtering-1.1.pom"
+    "org.sonatype.spice:spice-parent:pom:10": {
+      "layout": "org/sonatype/spice/spice-parent/10/spice-parent-10.pom",
+      "sha256": "683c012c6bf5e1e31b232b3755c027ccd829692a09c8216652b414b09d4ae623",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/10/spice-parent-10.pom"
+    },
+    "org.sonatype.spice:spice-parent:pom:12": {
+      "layout": "org/sonatype/spice/spice-parent/12/spice-parent-12.pom",
+      "sha256": "21a19b26dbe5c38ddb5114cf4eadbf5ccb411bc6b128fdd5949b1ccb12f3683e",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/12/spice-parent-12.pom"
+    },
+    "org.sonatype.spice:spice-parent:pom:16": {
+      "layout": "org/sonatype/spice/spice-parent/16/spice-parent-16.pom",
+      "sha256": "258f43b5e805687302a5bb400856b972a573ec42a44f949641354a84b9243758",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/16/spice-parent-16.pom"
+    },
+    "org.sonatype.spice:spice-parent:pom:17": {
+      "layout": "org/sonatype/spice/spice-parent/17/spice-parent-17.pom",
+      "sha256": "9151f9a5b33ec36ee8778842fc56144fb0242d39cbcc42061b053b8909969bdf",
+      "url": "https://repo.maven.apache.org/maven2/org/sonatype/spice/spice-parent/17/spice-parent-17.pom"
     }
   }
 }


### PR DESCRIPTION
On my system the integration test fails (at commit ea21cfe), because the order of the artifacts in the generated lockfile changes slightly. This pull request makes the order of the artifacts more predictable by ordering artifacts alphabetically. The pull request also includes some clean up commits.