### PR TITLE
Choose URL matching the hash of the local artifact

### DIFF
--- a/src/main/java/com/fzakaria/mvn2nix/cmd/Maven2nix.java
+++ b/src/main/java/com/fzakaria/mvn2nix/cmd/Maven2nix.java
@@ -5,8 +5,6 @@ import com.fzakaria.mvn2nix.maven.Maven;
 import com.fzakaria.mvn2nix.model.MavenArtifact;
 import com.fzakaria.mvn2nix.model.MavenNixInformation;
 import com.fzakaria.mvn2nix.model.URLAdapter;
-import com.google.common.hash.Hashing;
-import com.google.common.io.Files;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import org.slf4j.Logger;
@@ -84,12 +82,7 @@ public class Maven2nix implements Callable<Integer> {
                                         LOGGER.info("URL does not exist: {}", url);
                                         continue;
                                     }
-
-                                    File localArtifact = maven.findArtifactInLocalRepository(artifact)
-                                            .orElseThrow(() -> new IllegalStateException("Should never happen"));
-
-                                    String sha256 = calculateSha256OfFile(localArtifact);
-                                    return new MavenArtifact(url, artifact.getLayout(), sha256);
+                                    return new MavenArtifact(url, artifact.getLayout(), artifact.getSha256());
                                 }
                                 throw new RuntimeException(String.format("Could not find artifact %s in any repository", artifact));
                             }
@@ -127,14 +120,6 @@ public class Maven2nix implements Callable<Integer> {
             return new URL(url + artifact.getLayout());
         } catch (MalformedURLException e) {
             throw new RuntimeException("Could not contact repository: " + url);
-        }
-    }
-
-    public static String calculateSha256OfFile(File file) {
-        try {
-            return Files.asByteSource(file).hash(Hashing.sha256()).toString();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
         }
     }
 

--- a/src/main/java/com/fzakaria/mvn2nix/cmd/Maven2nix.java
+++ b/src/main/java/com/fzakaria/mvn2nix/cmd/Maven2nix.java
@@ -65,7 +65,7 @@ public class Maven2nix implements Callable<Integer> {
     }
 
     @Override
-    public Integer call() throws Exception {
+    public Integer call() {
         LOGGER.info("Reading {}", file);
 
         final Maven maven = Maven.withTemporaryLocalRepository();

--- a/src/main/java/com/fzakaria/mvn2nix/cmd/Maven2nix.java
+++ b/src/main/java/com/fzakaria/mvn2nix/cmd/Maven2nix.java
@@ -61,7 +61,13 @@ public class Maven2nix implements Callable<Integer> {
             defaultValue = "${java.home}")
     private File javaHome;
     
+    private ArtifactResolver resolver;
+
     public Maven2nix() {
+        this.resolver = Maven2nix::doesUrlExist;
+    }
+    public Maven2nix(ArtifactResolver resolver) {
+        this.resolver = resolver;
     }
 
     @Override
@@ -87,13 +93,18 @@ public class Maven2nix implements Callable<Integer> {
     private URL artifactUrl(Artifact artifact) {
         for (String repository : repositories) {
             URL url = getRepositoryArtifactUrl(artifact, repository);
-            if (!doesUrlExist(url)) {
+            if (!resolver.doesExist(url)) {
                 LOGGER.info("URL does not exist: {}", url);
                 continue;
             }
             return url;
         }
         throw new RuntimeException(String.format("Could not find artifact %s in any repository", artifact));
+    }
+
+    @FunctionalInterface
+    public interface ArtifactResolver {
+        boolean doesExist(URL artifact);
     }
 
     /**

--- a/src/main/java/com/fzakaria/mvn2nix/maven/Artifact.java
+++ b/src/main/java/com/fzakaria/mvn2nix/maven/Artifact.java
@@ -22,24 +22,8 @@ public class Artifact {
         this.extension = extension;
     }
 
-    public String getGroup() {
-        return group;
-    }
-
     public String getName() {
         return name;
-    }
-
-    public String getVersion() {
-        return version;
-    }
-
-    public String getClassifier() {
-        return classifier;
-    }
-
-    public String getExtension() {
-        return extension;
     }
 
     @Override

--- a/src/main/java/com/fzakaria/mvn2nix/maven/Artifact.java
+++ b/src/main/java/com/fzakaria/mvn2nix/maven/Artifact.java
@@ -14,16 +14,23 @@ public class Artifact {
     private final String classifier;
     private final String extension;
 
-    public Artifact(String group, String name, String version, String classifier, String extension) {
+    private final String sha256;
+
+    public Artifact(String group, String name, String version, String classifier, String extension, String sha256) {
         this.group = group;
         this.name = name;
         this.version = version;
         this.classifier = classifier;
         this.extension = extension;
+        this.sha256 = sha256;
     }
 
     public String getName() {
         return name;
+    }
+
+    public String getSha256() {
+        return sha256;
     }
 
     @Override
@@ -35,7 +42,8 @@ public class Artifact {
                 Objects.equals(name, artifact.name) &&
                 Objects.equals(version, artifact.version) &&
                 Objects.equals(classifier, artifact.classifier) &&
-                Objects.equals(extension, artifact.extension);
+                Objects.equals(extension, artifact.extension) &&
+                Objects.equals(sha256, artifact.sha256);
     }
 
     /**
@@ -71,7 +79,7 @@ public class Artifact {
 
     @Override
     public int hashCode() {
-        return Objects.hash(group, name, version, classifier, extension);
+        return Objects.hash(group, name, version, classifier, extension, sha256);
     }
 
     @Override
@@ -123,6 +131,8 @@ public class Artifact {
         private String classifier;
         private String extension;
 
+        private String sha256;
+
         public Builder setGroup(String group) {
             this.group = group;
             return this;
@@ -148,8 +158,13 @@ public class Artifact {
             return this;
         }
 
+        public Builder setSha256(String sha256) {
+            this.sha256 = sha256;
+            return this;
+        }
+
         public Artifact build() {
-            return new Artifact(group, name, version, classifier, extension);
+            return new Artifact(group, name, version, classifier, extension, sha256);
         }
     }
 }

--- a/src/main/java/com/fzakaria/mvn2nix/maven/Maven.java
+++ b/src/main/java/com/fzakaria/mvn2nix/maven/Maven.java
@@ -3,6 +3,7 @@ package com.fzakaria.mvn2nix.maven;
 import com.fzakaria.mvn2nix.util.Resources;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.google.common.hash.Hashing;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.io.IoBuilder;
 import org.apache.maven.shared.invoker.DefaultInvocationRequest;
@@ -21,7 +22,6 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -68,20 +68,6 @@ public class Maven {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
-    }
-
-    /**
-     * Return the local File for the provided artifact if it exists.
-     * The ephemeral local repository is checked only.
-     * @param artifact
-     * @return
-     */
-    public Optional<File> findArtifactInLocalRepository(Artifact artifact) {
-        File file = localRepository.toPath().resolve(artifact.getLayout()).toFile();
-        if (!file.exists()) {
-            return Optional.empty();
-        }
-        return Optional.of(file);
     }
 
     public void executeGoals(File pom, File javaHome, String... goals) throws MavenInvocationException {
@@ -154,6 +140,7 @@ public class Maven {
                              .setClassifier(classifier)
                              .setVersion(version)
                              .setExtension(extension)
+                             .setSha256(calculateSha256OfFile(file.toFile()))
                              .build();
                  })
                 .filter(Objects::nonNull)
@@ -163,4 +150,11 @@ public class Maven {
         }
     }
 
+    private static String calculateSha256OfFile(File file) {
+        try {
+            return com.google.common.io.Files.asByteSource(file).hash(Hashing.sha256()).toString();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
 }

--- a/src/main/java/com/fzakaria/mvn2nix/maven/Maven.java
+++ b/src/main/java/com/fzakaria/mvn2nix/maven/Maven.java
@@ -70,7 +70,7 @@ public class Maven {
         }
     }
 
-    public void executeGoals(File pom, File javaHome, String... goals) throws MavenInvocationException {
+    public void executeGoals(File pom, File javaHome, String... goals) {
         InvocationRequest request = new DefaultInvocationRequest();
         request.setGoals(Lists.newArrayList(goals));
         request.setBatchMode(true);
@@ -82,13 +82,16 @@ public class Maven {
          * This will cut down drastically on the network calls to re-hydrate this temporary local repo.
          */
         request.setGlobalSettingsFile(Resources.export("settings.xml"));
-
-        InvocationResult result = this.invoker.execute(request);
-        if (result.getExitCode() != 0) {
-            throw new MavenInvocationException(
-                    String.format("Failed to execute goals [%s]. Exit code: %s", Arrays.toString(goals), result.getExitCode()),
-                    result.getExecutionException()
-            );
+        try {
+            InvocationResult result = this.invoker.execute(request);
+            if (result.getExitCode() != 0) {
+                throw new MavenInvocationException(
+                        String.format("Failed to execute goals [%s]. Exit code: %s", Arrays.toString(goals), result.getExitCode()),
+                        result.getExecutionException()
+                );
+            }
+        } catch (MavenInvocationException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/com/fzakaria/mvn2nix/model/MavenNixInformation.java
+++ b/src/main/java/com/fzakaria/mvn2nix/model/MavenNixInformation.java
@@ -10,6 +10,9 @@ import java.util.TreeMap;
 @Immutable
 public class MavenNixInformation {
 
+    /**
+     * Maps canonical names to the artifact data.
+     */
     private final Map<String, MavenArtifact> dependencies;
 
     /**
@@ -18,6 +21,10 @@ public class MavenNixInformation {
      */
     public MavenNixInformation(Map<String, MavenArtifact> dependencies) {
         this.dependencies = new TreeMap<>(dependencies);
+    }
+
+    public MavenArtifact byCanonicalName(String canonicalName) {
+        return dependencies.get(canonicalName);
     }
 
     @Override

--- a/src/main/java/com/fzakaria/mvn2nix/model/MavenNixInformation.java
+++ b/src/main/java/com/fzakaria/mvn2nix/model/MavenNixInformation.java
@@ -3,7 +3,6 @@ package com.fzakaria.mvn2nix.model;
 import com.google.common.base.MoreObjects;
 
 import javax.annotation.concurrent.Immutable;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.TreeMap;

--- a/src/test/java/com/fzakaria/mvn2nix/cmd/Sha256MatchTest.java
+++ b/src/test/java/com/fzakaria/mvn2nix/cmd/Sha256MatchTest.java
@@ -1,0 +1,57 @@
+package com.fzakaria.mvn2nix.cmd;
+
+import com.fzakaria.mvn2nix.maven.Artifact;
+import com.fzakaria.mvn2nix.util.Resources;
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Collection;
+
+import static com.fzakaria.mvn2nix.cmd.Maven2nix.mavenNixInformation;
+import static com.fzakaria.mvn2nix.cmd.Maven2nix.toPrettyJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests whether the sha256 determined by the artifact analysis matches the
+ * sha256 of the artifact in the url associated with the artifact.
+ *
+ * In this test an artifact is found with the sha of the file in repository 2. However, the mvn2nix
+ * resolver associates the artifact with repository 1 where it has a different SHA-256.
+ */
+@Nested
+class Sha256MatchTest {
+
+    private static Artifact artifactA = new Artifact("group-a", "name-a", "version-a", "classifier-a", "jar", "sha-a-in-repo-2");
+
+    @Disabled("Hashes do not match")
+    @Test
+    public void artifactUrlsWithMultipleRepositories() {
+        var repositories = new String[]{"https://repo-1/", "https://repo-2"};
+        var artifactInfo = mavenNixInformation(Sha256MatchTest::fakeArtifactResolver, Sha256MatchTest::fakeArtifactAnalysis, repositories)
+                .byCanonicalName(artifactA.getCanonicalName());
+        assertEquals(artifactInfo.getSha256(), sha256(artifactInfo.getUrl()));
+    }
+
+    private static String sha256(URL url) {
+        switch (url.toString()) {
+            case "https://repo-1/group-a/name-a/version-a/name-a-version-a-classifier-a.jar":
+                return "sha-a-in-repo-1";
+            case "https://repo-2/group-a/name-a/version-a/name-a-version-a-classifier-a.jar":
+                return "sha-a-in-repo-2";
+            default: throw new IllegalStateException("All cases covered!");
+        }
+    }
+
+    private static boolean fakeArtifactResolver(URL artifact) {
+        return true;
+    }
+
+    private static Collection<Artifact> fakeArtifactAnalysis() {
+        return ImmutableList.of(artifactA);
+    }
+}

--- a/src/test/java/com/fzakaria/mvn2nix/cmd/Sha256MatchTest.java
+++ b/src/test/java/com/fzakaria/mvn2nix/cmd/Sha256MatchTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.net.URL;
 import java.util.Collection;
+import java.util.Optional;
 
 import static com.fzakaria.mvn2nix.cmd.Maven2nix.mavenNixInformation;
 import static com.fzakaria.mvn2nix.cmd.Maven2nix.toPrettyJson;
@@ -28,27 +29,22 @@ class Sha256MatchTest {
 
     private static Artifact artifactA = new Artifact("group-a", "name-a", "version-a", "classifier-a", "jar", "sha-a-in-repo-2");
 
-    @Disabled("Hashes do not match")
     @Test
     public void artifactUrlsWithMultipleRepositories() {
         var repositories = new String[]{"https://repo-1/", "https://repo-2"};
-        var artifactInfo = mavenNixInformation(Sha256MatchTest::fakeArtifactResolver, Sha256MatchTest::fakeArtifactAnalysis, repositories)
+        var artifactInfo = mavenNixInformation(Sha256MatchTest::sha256, Sha256MatchTest::fakeArtifactAnalysis, repositories)
                 .byCanonicalName(artifactA.getCanonicalName());
-        assertEquals(artifactInfo.getSha256(), sha256(artifactInfo.getUrl()));
+        assertEquals(artifactInfo.getSha256(), sha256(artifactInfo.getUrl()).get());
     }
 
-    private static String sha256(URL url) {
+    private static Optional<String> sha256(URL url) {
         switch (url.toString()) {
             case "https://repo-1/group-a/name-a/version-a/name-a-version-a-classifier-a.jar":
-                return "sha-a-in-repo-1";
+                return Optional.of("sha-a-in-repo-1");
             case "https://repo-2/group-a/name-a/version-a/name-a-version-a-classifier-a.jar":
-                return "sha-a-in-repo-2";
-            default: throw new IllegalStateException("All cases covered!");
+                return Optional.of("sha-a-in-repo-2");
         }
-    }
-
-    private static boolean fakeArtifactResolver(URL artifact) {
-        return true;
+        return Optional.empty();
     }
 
     private static Collection<Artifact> fakeArtifactAnalysis() {

--- a/src/test/java/com/fzakaria/mvn2nix/cmd/UrlResolutionTest.java
+++ b/src/test/java/com/fzakaria/mvn2nix/cmd/UrlResolutionTest.java
@@ -1,17 +1,14 @@
 package com.fzakaria.mvn2nix.cmd;
 
 import com.fzakaria.mvn2nix.maven.Artifact;
-import com.fzakaria.mvn2nix.util.Resources;
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
-import picocli.CommandLine;
 
-import java.io.File;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.net.URL;
 import java.util.Collection;
 
+import static com.fzakaria.mvn2nix.cmd.Maven2nix.mavenNixInformation;
+import static com.fzakaria.mvn2nix.cmd.Maven2nix.toPrettyJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class UrlResolutionTest {
@@ -24,16 +21,9 @@ public class UrlResolutionTest {
      */
     @Test
     public void artifactUrlsWithMultipleRepositories() {
-        Maven2nix app = new Maven2nix(UrlResolutionTest::fakeArtifactResolver, UrlResolutionTest::fakeArtifactAnalysis);
-        CommandLine cmd = new CommandLine(app);
-        StringWriter sw = new StringWriter();
-        cmd.setOut(new PrintWriter(sw));
-
-        File pom = Resources.export("samples/basic/pom.xml");
-        cmd.execute(pom.getPath(), "--repositories", "https://repo-1/", "https://repo-2");
-
-        String actual = sw.getBuffer().toString();
-        assertThat(actual).isEqualToIgnoringNewLines("{\n" +
+        var repositories = new String[] {"https://repo-1/", "https://repo-2"};
+        assertThat(toPrettyJson(mavenNixInformation(UrlResolutionTest::fakeArtifactResolver, UrlResolutionTest::fakeArtifactAnalysis, repositories)))
+                .isEqualToIgnoringNewLines("{\n" +
                 "  \"dependencies\": {\n" +
                 "    \"group-a:name-a:jar:classifier-a:version-a\": {\n" +
                 "      \"layout\": \"group-a/name-a/version-a/name-a-version-a-classifier-a.jar\",\n" +

--- a/src/test/java/com/fzakaria/mvn2nix/cmd/UrlResolutionTest.java
+++ b/src/test/java/com/fzakaria/mvn2nix/cmd/UrlResolutionTest.java
@@ -1,0 +1,62 @@
+package com.fzakaria.mvn2nix.cmd;
+
+import com.fzakaria.mvn2nix.maven.Artifact;
+import com.fzakaria.mvn2nix.util.Resources;
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.URL;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UrlResolutionTest {
+
+    /**
+     * This test checks that the artifacts are resolved against all the repositories.
+     *
+     * In particular the artifact A is not found in repository 1, but is found in repository 2.
+     * Therefore the URL of this artifact should point to repository 2.
+     */
+    @Test
+    public void artifactUrlsWithMultipleRepositories() {
+        Maven2nix app = new Maven2nix(UrlResolutionTest::fakeArtifactResolver, UrlResolutionTest::fakeArtifactAnalysis);
+        CommandLine cmd = new CommandLine(app);
+        StringWriter sw = new StringWriter();
+        cmd.setOut(new PrintWriter(sw));
+
+        File pom = Resources.export("samples/basic/pom.xml");
+        cmd.execute(pom.getPath(), "--repositories", "https://repo-1/", "https://repo-2");
+
+        String actual = sw.getBuffer().toString();
+        assertThat(actual).isEqualToIgnoringNewLines("{\n" +
+                "  \"dependencies\": {\n" +
+                "    \"group-a:name-a:jar:classifier-a:version-a\": {\n" +
+                "      \"layout\": \"group-a/name-a/version-a/name-a-version-a-classifier-a.jar\",\n" +
+                "      \"sha256\": \"sha-a\",\n" +
+                "      \"url\": \"https://repo-2/group-a/name-a/version-a/name-a-version-a-classifier-a.jar\"\n" +
+                "    },\n" +
+                "    \"group-b:name-b:jar:classifier-b:version-b\": {\n" +
+                "      \"layout\": \"group-b/name-b/version-b/name-b-version-b-classifier-b.jar\",\n" +
+                "      \"sha256\": \"sha-b\",\n" +
+                "      \"url\": \"https://repo-1/group-b/name-b/version-b/name-b-version-b-classifier-b.jar\"\n" +
+                "    }\n" +
+                "  }\n" +
+                "}");
+    }
+
+    private static boolean fakeArtifactResolver(URL artifact) {
+        return !"https://repo-1/group-a/name-a/version-a/name-a-version-a-classifier-a.jar".equals(artifact.toString());
+    }
+
+    private static Collection<Artifact> fakeArtifactAnalysis() {
+        return ImmutableList.of(
+                new Artifact("group-a", "name-a", "version-a", "classifier-a", "jar", "sha-a"),
+                new Artifact("group-b", "name-b", "version-b", "classifier-b", "jar", "sha-b")
+        );
+    }
+}

--- a/src/test/java/com/fzakaria/mvn2nix/cmd/UrlResolutionTest.java
+++ b/src/test/java/com/fzakaria/mvn2nix/cmd/UrlResolutionTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.net.URL;
 import java.util.Collection;
+import java.util.Optional;
 
 import static com.fzakaria.mvn2nix.cmd.Maven2nix.mavenNixInformation;
 import static com.fzakaria.mvn2nix.cmd.Maven2nix.toPrettyJson;
@@ -39,8 +40,14 @@ public class UrlResolutionTest {
                 "}");
     }
 
-    private static boolean fakeArtifactResolver(URL artifact) {
-        return !"https://repo-1/group-a/name-a/version-a/name-a-version-a-classifier-a.jar".equals(artifact.toString());
+    private static Optional<String> fakeArtifactResolver(URL artifact) {
+        switch (artifact.toString()) {
+            case "https://repo-2/group-a/name-a/version-a/name-a-version-a-classifier-a.jar":
+                return Optional.of("sha-a");
+            case "https://repo-1/group-b/name-b/version-b/name-b-version-b-classifier-b.jar":
+                return Optional.of("sha-b");
+        }
+        return Optional.empty();
     }
 
     private static Collection<Artifact> fakeArtifactAnalysis() {


### PR DESCRIPTION
This PR changes the behavior of mvn2nix such that it uses the URL which matches the hash of the artifact in the local repository. This should solve mismatches such as reported in Issue #29. The URL of an artifact is determined by retrieving the artifact from the URL, computing its SHA256 and comparing it to the SHA256 of the local artifact. As a consequence each artifact has to be downloaded at least once for the creation of the lockfile.

Furthermore, I have abstracted parts of the algorithm in order to make unit testing somewhat easier. In particular, the PR includes a test that produces a hash mismatch which is fixed by the new way to choose the artifact URL. 