### PR TITLE
handle file URLs

### DIFF
--- a/src/main/java/com/fzakaria/mvn2nix/cmd/Maven2nix.java
+++ b/src/main/java/com/fzakaria/mvn2nix/cmd/Maven2nix.java
@@ -125,6 +125,9 @@ public class Maven2nix implements Callable<Integer> {
         if (!url.endsWith("/")) {
             url += "/";
         }
+        if (url.startsWith("/")) {
+            url = "file:" + url;
+        }
         try {
             return new URL(url + artifact.getLayout());
         } catch (MalformedURLException e) {

--- a/src/main/java/com/fzakaria/mvn2nix/cmd/Maven2nix.java
+++ b/src/main/java/com/fzakaria/mvn2nix/cmd/Maven2nix.java
@@ -21,6 +21,8 @@ import picocli.CommandLine.Spec;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -146,6 +148,15 @@ public class Maven2nix implements Callable<Integer> {
      */
     public static boolean doesUrlExist(URL url) {
         try {
+            if (url.getProtocol().equals("file")) {
+                try {
+                    Path path = Paths.get(url.toURI());
+                    return java.nio.file.Files.exists(path);
+                } catch (java.net.URISyntaxException e) {
+                    return false;
+                }
+            }
+
             URLConnection urlConnection = url.openConnection();
             if (!(urlConnection instanceof HttpURLConnection)) {
                 return false;


### PR DESCRIPTION
failed attempt to fix #15 

failed, because nix store paths should not be stored in the lockfile `mvn2nix-lock.json`
instead, this should be done as suggested in https://github.com/fzakaria/mvn2nix/issues/15#issuecomment-680191922

---

im want to build [qortal](https://github.com/Qortal/qortal)
which requires some dependencies (`jar` and `pom` files)
which are not available in maven repositories

for example, i want to build the dependency [WaifUPnP 1.3](https://github.com/IceBurst/WaifUPnP) from source

<details>
<summary>
pkgs/by-name/ic/iceburst-waifupnp/package.nix
</summary>

```nix
{
  lib,
  stdenv,
  fetchFromGitHub,
  jdk,
  mvn2nix,
  maven,
}:

/*
  git clone --depth=1 https://github.com/IceBurst/WaifUPnP
  cd WaifUPnP
  mvn2nix --jdk $(nix-build --no-out-link '<nixpkgs>' -A openjdk11)/lib/openjdk >mvn2nix-lock.json
*/

let
  mavenRepository =
    mvn2nix.buildMavenRepositoryFromLockFile { file = ./mvn2nix-lock.json; };
in

stdenv.mkDerivation rec {

  pname = "waifupnp";
  version = "1.3";

  src = fetchFromGitHub {
    owner = "IceBurst";
    repo = "WaifUPnP";
    rev = "c3350f6a15ec7b9432d4eabc488460d79fd3f0be";
    hash = "sha256-KANEE4MX9xvFpB1OfQNAX/qyoW5hB5HHTSNkMAaNBvo=";
  };

  nativeBuildInputs = [
    jdk
    maven
  ];

  buildPhase = ''
    echo "Building with maven repository ${mavenRepository}"
    mvn package --offline -Dmaven.repo.local=${mavenRepository}
  '';

  installPhase = ''
    mkdir -p $out/lib
    cp target/*.jar $out/lib

    cat >$out/lib/WaifUPnP-${version}.pom <<EOF
    <project xmlns="http://maven.apache.org/POM/4.0.0">
      <modelVersion>4.0.0</modelVersion>
      <groupId>com.dosse</groupId>
      <artifactId>WaifUPnP</artifactId>
      <version>${version}</version>
    </project>
    EOF

    mkdir -p $out/lib/com/dosse/WaifUPnP
    ln -sr $out/lib $out/lib/com/dosse/WaifUPnP/${version}
  '';

  meta = {
    description = "UPnP Port Forwarding for Java";
    homepage = "https://github.com/IceBurst/WaifUPnP";
    license = lib.licenses.lgpl21Only;
    maintainers = with lib.maintainers; [ ];
    mainProgram = "waifupnp";
    platforms = lib.platforms.all;
  };
}
```

</details>

... and pass the nix store path of `WaifUPnP` to `mvn2nix` like

```
cd qortal
$(nix-build --no-out-link "<nixpkgs>" -A nur.repos.milahu.mvn2nix)/bin/mvn2nix \
  --jdk $(nix-build --no-out-link '<nixpkgs>' -A openjdk11)/lib/openjdk \
  --goals package \
  --goals "-DskipTests=true" \
  --repositories https://jitpack.io/ \
  --repositories https://repo.maven.apache.org/maven2/ \
  --repositories https://repository.cloudera.com/artifactory/ \
  --repositories file:$(nix-build --no-out-link "<nixpkgs>" -A nur.repos.milahu.iceburst-waifupnp)/lib \
  >mvn2nix-lock.json
```

but `mvn2nix` fails with
`[ForkJoinPool.commonPool-worker-2] INFO : URL does not exist: file:/nix/store/6vn6ypvx9kikk90pawisqxjk23gfhc3v-waifupnp-1.3/lib/com/dosse/WaifUPnP/1.3/WaifUPnP-1.3.pom`
`java.lang.RuntimeException: Could not find artifact com.dosse:WaifUPnP:pom:1.3 in any repository`

but the `pom` file exists
`/nix/store/6vn6ypvx9kikk90pawisqxjk23gfhc3v-waifupnp-1.3/lib/com/dosse/WaifUPnP/1.3/WaifUPnP-1.3.pom`

```xml
<project xmlns="http://maven.apache.org/POM/4.0.0">
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.dosse</groupId>
  <artifactId>WaifUPnP</artifactId>
  <version>1.3</version>
</project>
```

the error message `URL does not exist` comes from

https://github.com/fzakaria/mvn2nix/blob/88d4cdda093c7a6b3c09404d3b4c2aa0b3c1fd0c/src/main/java/com/fzakaria/mvn2nix/cmd/Maven2nix.java#L82-L84

this PR

- fixes the `doesUrlExist` function to handle file URLs
- allows passing absolute repository paths like `/nix/store/...` instead of file URLs

exampe output mvn2nix-lock.json

```json
{
  "dependencies": {
    "avalon-framework:avalon-framework:pom:4.1.3": {
      "layout": "avalon-framework/avalon-framework/4.1.3/avalon-framework-4.1.3.pom",
      "sha256": "c6c971b146ec8e596e660e64d5517aae02e34c3cce240de44bb92ccd98f046bf",
      "url": "https://repo.maven.apache.org/maven2/avalon-framework/avalon-framework/4.1.3/avalon-framework-4.1.3.pom"
    },
    "com.dosse:WaifUPnP:jar:1.3": {
      "layout": "com/dosse/WaifUPnP/1.3/WaifUPnP-1.3.jar",
      "sha256": "eaca3aebe57e90fc32906cbad960218a4479e2ebb7cecff48e9ee3767ce8b644",
      "url": "file:/nix/store/hls4vlybsf83vy3v12glwmrax2f31s51-waifupnp-1.3/lib/com/dosse/WaifUPnP/1.3/WaifUPnP-1.3.jar"
    },
    "com.dosse:WaifUPnP:pom:1.3": {
      "layout": "com/dosse/WaifUPnP/1.3/WaifUPnP-1.3.pom",
      "sha256": "87cde7ec6ce795bc3968ae9b1b49ce1f80137f8111ae9751c69ab5a5228bcb84",
      "url": "file:/nix/store/hls4vlybsf83vy3v12glwmrax2f31s51-waifupnp-1.3/lib/com/dosse/WaifUPnP/1.3/WaifUPnP-1.3.pom"
    },
```

but now [mvn2nix.buildMavenRepositoryFromLockFile](https://github.com/fzakaria/mvn2nix/blob/88d4cdda093c7a6b3c09404d3b4c2aa0b3c1fd0c/maven.nix#L31) fails with

```
trying file:/nix/store/hls4vlybsf83vy3v12glwmrax2f31s51-waifupnp-1.3/lib/com/dosse/WaifUPnP/1.3/WaifUPnP-1.3.jar
curl: (37) Couldn't open file /nix/store/hls4vlybsf83vy3v12glwmrax2f31s51-waifupnp-1.3/lib/com/dosse/WaifUPnP/1.3/WaifUPnP-1.3.jar
error: cannot download WaifUPnP-1.3.jar from any mirror
```

